### PR TITLE
CephFS: Added ENOENT checks for possible missing volumes

### DIFF
--- a/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-daemonset.yaml
@@ -167,7 +167,7 @@ spec:
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.registrationDir }}
             type: Directory
         - name: mountpoint-dir
           hostPath:

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.nodeplugin.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "ceph-csi-cephfs.nodeplugin.fullname" . }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.fullname" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+    - pathPrefix: '/var/lib/kubelet/pods'
+      readOnly: false
+    - pathPrefix: '{{ .Values.socketDir }}'
+      readOnly: false
+    - pathPrefix: '{{ .Values.registrationDir }}'
+      readOnly: false
+    - pathPrefix: '{{ .Values.pluginDir }}'
+      readOnly: false
+{{- end }}

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-role.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-role.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.rbac.create .Values.nodeplugin.podSecurityPolicy.enabled -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph-csi-cephfs.nodeplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.fullname" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['{{ include "ceph-csi-cephfs.nodeplugin.fullname" . }}']
+{{- end -}}

--- a/charts/ceph-csi-cephfs/templates/nodeplugin-rolebinding.yaml
+++ b/charts/ceph-csi-cephfs/templates/nodeplugin-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.rbac.create .Values.nodeplugin.podSecurityPolicy.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph-csi-cephfs.nodeplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.fullname" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ceph-csi-cephfs.serviceAccountName.nodeplugin" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "ceph-csi-cephfs.nodeplugin.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/ceph-csi-cephfs/templates/provisioner-psp.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-psp.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.provisioner.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "ceph-csi-cephfs.provisioner.fullname" . }}
+  labels:
+    app: {{ include "ceph-csi-cephfs.name" . }}
+    chart: {{ include "ceph-csi-cephfs.chart" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+{{- end }}

--- a/charts/ceph-csi-cephfs/templates/provisioner-role.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-role.yaml
@@ -20,4 +20,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- if .Values.provisioner.podSecurityPolicy.enabled }}
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['{{ include "ceph-csi-cephfs.provisioner.fullname" . }}']
+{{- end -}}
 {{- end -}}

--- a/charts/ceph-csi-cephfs/values.yaml
+++ b/charts/ceph-csi-cephfs/values.yaml
@@ -114,6 +114,11 @@ nodeplugin:
 
   affinity: {}
 
+  # If true, create & use Pod Security Policy resources
+  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  podSecurityPolicy:
+    enabled: false
+
 provisioner:
   name: provisioner
   replicaCount: 3
@@ -212,6 +217,11 @@ provisioner:
   tolerations: []
 
   affinity: {}
+
+  # If true, create & use Pod Security Policy resources
+  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  podSecurityPolicy:
+    enabled: false
 
 #########################################################
 # Variables for 'internal' use please use with caution! #

--- a/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.nodeplugin.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+    - pathPrefix: '/var/lib/kubelet/pods'
+      readOnly: false
+    - pathPrefix: '{{ .Values.socketDir }}'
+      readOnly: false
+    - pathPrefix: '{{ .Values.registrationDir }}'
+      readOnly: false
+    - pathPrefix: '{{ .Values.pluginDir }}'
+      readOnly: false
+{{- end }}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-role.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-role.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.rbac.create .Values.nodeplugin.podSecurityPolicy.enabled -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['{{ include "ceph-csi-rbd.nodeplugin.fullname" . }}']
+{{- end -}}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-rolebinding.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.rbac.create .Values.nodeplugin.podSecurityPolicy.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.nodeplugin.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "ceph-csi-rbd.serviceAccountName.nodeplugin" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "ceph-csi-rbd.nodeplugin.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/ceph-csi-rbd/templates/provisioner-psp.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-psp.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.provisioner.podSecurityPolicy.enabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "ceph-csi-rbd.provisioner.fullname" . }}
+  labels:
+    app: {{ include "ceph-csi-rbd.name" . }}
+    chart: {{ include "ceph-csi-rbd.chart" . }}
+    component: {{ .Values.provisioner.name }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+{{- end }}

--- a/charts/ceph-csi-rbd/templates/provisioner-role.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-role.yaml
@@ -17,4 +17,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "watch", "list", "delete", "update", "create"]
+{{- if .Values.provisioner.podSecurityPolicy.enabled }}
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['{{ include "ceph-csi-rbd.provisioner.fullname" . }}']
+{{- end -}}
 {{- end -}}

--- a/charts/ceph-csi-rbd/values.yaml
+++ b/charts/ceph-csi-rbd/values.yaml
@@ -114,6 +114,11 @@ nodeplugin:
 
   affinity: {}
 
+  # If true, create & use Pod Security Policy resources
+  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  podSecurityPolicy:
+    enabled: false
+
 provisioner:
   name: provisioner
   replicaCount: 3
@@ -219,6 +224,11 @@ provisioner:
   tolerations: []
 
   affinity: {}
+
+  # If true, create & use Pod Security Policy resources
+  # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  podSecurityPolicy:
+    enabled: false
 
 #########################################################
 # Variables for 'internal' use please use with caution! #

--- a/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-nodeplugin-psp.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cephfs-csi-nodeplugin-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+    - pathPrefix: '/var/lib/kubelet/pods'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins/cephfs.csi.ceph.com'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins_registry'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins'
+      readOnly: false
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin-psp
+  # replace with non-default namespace name
+  namespace: default
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['cephfs-csi-nodeplugin-psp']
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-nodeplugin-psp
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-csi-nodeplugin
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: cephfs-csi-nodeplugin-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/cephfs/kubernetes/csi-provisioner-psp.yaml
+++ b/deploy/cephfs/kubernetes/csi-provisioner-psp.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: cephfs-csi-provisioner-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-provisioner-psp
+  # replace with non-default namespace name
+  namespace: default
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['cephfs-csi-provisioner-psp']
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cephfs-csi-provisioner-psp
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: cephfs-csi-provisioner
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: cephfs-csi-provisioner-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-psp.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: rbd-csi-nodeplugin-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  hostNetwork: true
+  hostPID: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+    - pathPrefix: '/var/lib/kubelet/pods'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins/rbd.csi.ceph.com'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins_registry'
+      readOnly: false
+    - pathPrefix: '/var/lib/kubelet/plugins'
+      readOnly: false
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-nodeplugin-psp
+  # replace with non-default namespace name
+  namespace: default
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['rbd-csi-nodeplugin-psp']
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-nodeplugin-psp
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: rbd-csi-nodeplugin
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: rbd-csi-nodeplugin-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/rbd/kubernetes/csi-provisioner-psp.yaml
+++ b/deploy/rbd/kubernetes/csi-provisioner-psp.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: rbd-csi-provisioner-psp
+spec:
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - 'SYS_ADMIN'
+  fsGroup:
+    rule: RunAsAny
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'hostPath'
+  allowedHostPaths:
+    - pathPrefix: '/dev'
+      readOnly: false
+    - pathPrefix: '/sys'
+      readOnly: false
+    - pathPrefix: '/lib/modules'
+      readOnly: true
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # replace with non-default namespace name
+  namespace: default
+  name: rbd-csi-provisioner-psp
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['rbd-csi-provisioner-psp']
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rbd-csi-provisioner-psp
+  # replace with non-default namespace name
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: rbd-csi-provisioner
+    # replace with non-default namespace name
+    namespace: default
+roleRef:
+  kind: Role
+  name: rbd-csi-provisioner-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/deploy-cephfs.md
+++ b/docs/deploy-cephfs.md
@@ -138,6 +138,16 @@ Those manifests deploy service accounts, cluster roles and cluster role
 bindings. These are shared for both RBD and CephFS CSI plugins, as they require
 the same permissions.
 
+**Deploy PodSecurityPolicy resources for sidecar containers and node plugins:**
+
+**NOTE:** These manifests are required only if [PodSecurityPolicy](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy)
+admission controller is active on your cluster.
+
+```bash
+kubectl create -f csi-provisioner-psp.yaml
+kubectl create -f csi-nodeplugin-psp.yaml
+```
+
 **Deploy ConfigMap for CSI plugins:**
 
 ```bash

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -94,6 +94,16 @@ Those manifests deploy service accounts, cluster roles and cluster role
 bindings. These are shared for both RBD and CephFS CSI plugins, as they require
 the same permissions.
 
+**Deploy PodSecurityPolicy resources for sidecar containers and node plugins:**
+
+**NOTE:** These manifests are required only if [PodSecurityPolicy](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy)
+admission controller is active on your cluster.
+
+```bash
+kubectl create -f csi-provisioner-psp.yaml
+kubectl create -f csi-nodeplugin-psp.yaml
+```
+
 **Deploy ConfigMap for CSI plugins:**
 
 ```bash

--- a/e2e/cephfs.go
+++ b/e2e/cephfs.go
@@ -13,8 +13,10 @@ import (
 var (
 	cephfsProvisioner     = "csi-cephfsplugin-provisioner.yaml"
 	cephfsProvisionerRBAC = "csi-provisioner-rbac.yaml"
+	cephfsProvisionerPSP  = "csi-provisioner-psp.yaml"
 	cephfsNodePlugin      = "csi-cephfsplugin.yaml"
 	cephfsNodePluginRBAC  = "csi-nodeplugin-rbac.yaml"
+	cephfsNodePluginPSP   = "csi-nodeplugin-psp.yaml"
 	cephfsDeploymentName  = "csi-cephfsplugin-provisioner"
 	cephfsDeamonSetName   = "csi-cephfsplugin"
 	cephfsDirPath         = "../deploy/cephfs/kubernetes/"
@@ -28,9 +30,11 @@ func deployCephfsPlugin() {
 	// deploy provisioner
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisioner)
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisionerRBAC)
+	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsProvisionerPSP)
 	// deploy nodeplugin
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePlugin)
 	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePluginRBAC)
+	framework.RunKubectlOrDie("create", "-f", cephfsDirPath+cephfsNodePluginPSP)
 }
 
 func deleteCephfsPlugin() {
@@ -42,6 +46,10 @@ func deleteCephfsPlugin() {
 	if err != nil {
 		e2elog.Logf("failed to delete cephfs provisioner rbac %v", err)
 	}
+	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsProvisionerPSP)
+	if err != nil {
+		e2elog.Logf("failed to delete cephfs provisioner psp %v", err)
+	}
 	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePlugin)
 	if err != nil {
 		e2elog.Logf("failed to delete cephfs nodeplugin %v", err)
@@ -49,6 +57,10 @@ func deleteCephfsPlugin() {
 	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePluginRBAC)
 	if err != nil {
 		e2elog.Logf("failed to delete cephfs nodeplugin rbac %v", err)
+	}
+	_, err = framework.RunKubectl("delete", "-f", cephfsDirPath+cephfsNodePluginPSP)
+	if err != nil {
+		e2elog.Logf("failed to delete cephfs nodeplugin psp %v", err)
 	}
 }
 

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -13,8 +13,10 @@ import (
 var (
 	rbdProvisioner     = "csi-rbdplugin-provisioner.yaml"
 	rbdProvisionerRBAC = "csi-provisioner-rbac.yaml"
+	rbdProvisionerPSP  = "csi-provisioner-psp.yaml"
 	rbdNodePlugin      = "csi-rbdplugin.yaml"
 	rbdNodePluginRBAC  = "csi-nodeplugin-rbac.yaml"
+	rbdNodePluginPSP   = "csi-nodeplugin-psp.yaml"
 	configMap          = "csi-config-map.yaml"
 	rbdDirPath         = "../deploy/rbd/kubernetes/"
 	rbdExamplePath     = "../examples/rbd/"
@@ -30,9 +32,11 @@ func deployRBDPlugin() {
 	// deploy provisioner
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdProvisioner)
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdProvisionerRBAC)
+	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdProvisionerPSP)
 	// deploy nodeplugin
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdNodePlugin)
 	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdNodePluginRBAC)
+	framework.RunKubectlOrDie("create", "-f", rbdDirPath+rbdNodePluginPSP)
 }
 
 func deleteRBDPlugin() {
@@ -44,6 +48,10 @@ func deleteRBDPlugin() {
 	if err != nil {
 		e2elog.Logf("failed to delete provisioner rbac %v", err)
 	}
+	_, err = framework.RunKubectl("delete", "-f", rbdDirPath+rbdProvisionerPSP)
+	if err != nil {
+		e2elog.Logf("failed to delete provisioner psp %v", err)
+	}
 	_, err = framework.RunKubectl("delete", "-f", rbdDirPath+rbdNodePlugin)
 	if err != nil {
 		e2elog.Logf("failed to delete nodeplugin %v", err)
@@ -51,6 +59,10 @@ func deleteRBDPlugin() {
 	_, err = framework.RunKubectl("delete", "-f", rbdDirPath+rbdNodePluginRBAC)
 	if err != nil {
 		e2elog.Logf("failed to delete nodeplugin rbac %v", err)
+	}
+	_, err = framework.RunKubectl("delete", "-f", rbdDirPath+rbdNodePluginPSP)
+	if err != nil {
+		e2elog.Logf("failed to delete nodeplugin psp %v", err)
 	}
 }
 

--- a/examples/rbd/raw-block-pod.yaml
+++ b/examples/rbd/raw-block-pod.yaml
@@ -5,10 +5,9 @@ metadata:
   name: pod-with-raw-block-volume
 spec:
   containers:
-    - name: fc-container
-      image: fedora:26
-      command: ["/bin/sh", "-c"]
-      args: ["tail -f /dev/null"]
+    - name: centos
+      image: centos:latest
+      command: ["/bin/sleep", "infinity"]
       volumeDevices:
         - name: data
           devicePath: /dev/xvda

--- a/pkg/cephfs/controllerserver.go
+++ b/pkg/cephfs/controllerserver.go
@@ -243,7 +243,23 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 			return cs.deleteVolumeDeprecated(ctx, req)
 		}
 
-		return nil, status.Error(codes.Internal, err.Error())
+		// All errors other than ErrVolumeNotFound should return an error back to the caller
+		if _, ok := err.(ErrVolumeNotFound); !ok {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+
+		// If error is ErrImageNotFound then we failed to find the subvolume, but found the imageOMap
+		// to lead us to the image, hence the imageOMap needs to be garbage collected, by calling
+		// unreserve for the same
+		if acquired := cs.VolumeLocks.TryAcquire(volOptions.RequestName); !acquired {
+			return nil, status.Errorf(codes.Aborted, util.VolumeOperationAlreadyExistsFmt, volOptions.RequestName)
+		}
+		defer cs.VolumeLocks.Release(volOptions.RequestName)
+
+		if err = undoVolReservation(ctx, volOptions, *vID, secrets); err != nil {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
+		return &csi.DeleteVolumeResponse{}, nil
 	}
 
 	// lock out parallel delete and create requests against the same volume name as we
@@ -263,7 +279,10 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 
 	if err = purgeVolume(ctx, volumeID(vID.FsSubvolName), cr, volOptions); err != nil {
 		klog.Errorf(util.Log(ctx, "failed to delete volume %s: %v"), volID, err)
-		return nil, status.Error(codes.Internal, err.Error())
+		// All errors other than ErrVolumeNotFound should return an error back to the caller
+		if _, ok := err.(ErrVolumeNotFound); !ok {
+			return nil, status.Error(codes.Internal, err.Error())
+		}
 	}
 
 	if err := undoVolReservation(ctx, volOptions, *vID, secrets); err != nil {

--- a/pkg/cephfs/errors.go
+++ b/pkg/cephfs/errors.go
@@ -35,3 +35,12 @@ type ErrNonStaticVolume struct {
 func (e ErrNonStaticVolume) Error() string {
 	return e.err.Error()
 }
+
+// ErrVolumeNotFound is returned when a subvolume is not found in CephFS
+type ErrVolumeNotFound struct {
+	err error
+}
+
+func (e ErrVolumeNotFound) Error() string {
+	return e.err.Error()
+}

--- a/pkg/cephfs/volumeoptions.go
+++ b/pkg/cephfs/volumeoptions.go
@@ -245,12 +245,12 @@ func newVolumeOptionsFromVolID(ctx context.Context, volID string, volOpt, secret
 		}
 	}
 
+	volOptions.ProvisionVolume = true
+
 	volOptions.RootPath, err = getVolumeRootPathCeph(ctx, &volOptions, cr, volumeID(vid.FsSubvolName))
 	if err != nil {
-		return nil, nil, err
+		return &volOptions, &vid, err
 	}
-
-	volOptions.ProvisionVolume = true
 
 	return &volOptions, &vid, nil
 }

--- a/scripts/psp.yaml
+++ b/scripts/psp.yaml
@@ -1,0 +1,135 @@
+# Required PodSecurityPolicies, Roles and RoleBindings
+# for minikube to bootstrap when PSPs are enabled
+# https://minikube.sigs.k8s.io/docs/tutorials/using_psp/
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: "*"
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+    - "*"
+  volumes:
+    - "*"
+  hostNetwork: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: restricted
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:privileged
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - privileged
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: psp:restricted
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+rules:
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames:
+      - restricted
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default:restricted
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:restricted
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default:privileged
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: psp:privileged
+subjects:
+  - kind: Group
+    name: system:masters
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: system:nodes
+    apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: system:serviceaccounts:kube-system
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Added checks in DeleteVolume RPC, for image missing errors, and
taking appropriate actions to cleanup the CSI reservations.

Further removed forcing a volume purge, and instead added checks
for missing volume errors in purgeVolume.

This should now fix issues where an continuation of an interrupted
DeleteVolume call, that only deleted the backing volume, will
proceed and not error out.

Signed-off-by: ShyamsundarR <srangana@redhat.com>
(cherry picked from commit 35e8c3b3a58abc20be2ddde4a0a6b810ace93d5e)


