### PR TITLE
BUG 1806419: check subvolume present in backend

### DIFF
--- a/pkg/cephfs/fsjournal.go
+++ b/pkg/cephfs/fsjournal.go
@@ -67,6 +67,14 @@ func checkVolExists(ctx context.Context, volOptions *volumeOptions, secret map[s
 	}
 	vid.FsSubvolName = volJournal.NamingPrefix() + imageUUID
 
+	_, err = getVolumeRootPathCeph(ctx, volOptions, cr, volumeID(vid.FsSubvolName))
+	if err != nil {
+		if _, ok := err.(ErrVolumeNotFound); ok {
+			err = volJournal.UndoReservation(ctx, volOptions.Monitors, cr, volOptions.MetadataPool, vid.FsSubvolName, volOptions.RequestName)
+			return nil, err
+		}
+		return nil, err
+	}
 	// TODO: size checks
 
 	// found a volume already available, process and return it!


### PR DESCRIPTION
If a CreateVolume call is interrupted, post creating the required CSI journal entries, but prior to creating the backing CephFS subvolume, then a subsequent CreateVolume call will return
a valid response with a VolumeID that has it's backing image missing. This PR adds a check
for backend image if the image is not found it deletes the reserved keys in omap.

fixes #839

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
(cherry picked from commit 128f3fc2cf410209d63966a25b6ffc7f1e1331a3)

