### PR TITLE
cephfs: return volume not found error if volume does not exists

### DIFF
--- a/pkg/cephfs/volume.go
+++ b/pkg/cephfs/volume.go
@@ -38,6 +38,10 @@ var (
 	// Subvolume group create gets called every time the plugin loads, though it doesn't result in error
 	// its unnecessary
 	cephfsInit = false
+
+	// ceph returns `Error ENOENT:` when subvolume or subvolume group doesnot
+	// exist.
+	errNotFoundString = "Error ENOENT:"
 )
 
 func getCephRootVolumePathLocalDeprecated(volID volumeID) string {
@@ -50,10 +54,6 @@ func getVolumeRootPathCephDeprecated(volID volumeID) string {
 
 func getCephRootPathLocalDeprecated(volID volumeID) string {
 	return fmt.Sprintf("%s/controller/volumes/root-%s", PluginFolder, string(volID))
-}
-
-func getVolumeNotFoundErrorString(volID volumeID) string {
-	return fmt.Sprintf("Error ENOENT: Subvolume '%s' not found", string(volID))
 }
 
 func getVolumeRootPathCeph(ctx context.Context, volOptions *volumeOptions, cr *util.Credentials, volID volumeID) (string, error) {
@@ -72,9 +72,10 @@ func getVolumeRootPathCeph(ctx context.Context, volOptions *volumeOptions, cr *u
 		"--keyfile="+cr.KeyFile)
 
 	if err != nil {
-		klog.Errorf(util.Log(ctx, "failed to get the rootpath for the vol %s(%s)"), string(volID), err)
+		stdErrString := string(stderr)
+		klog.Errorf(util.Log(ctx, "failed to get the rootpath for the vol %s(%s) stdError %s"), string(volID), err, stdErrString)
 
-		if strings.Contains(string(stderr), getVolumeNotFoundErrorString(volID)) {
+		if strings.HasPrefix(stdErrString, errNotFoundString) {
 			return "", ErrVolumeNotFound{err}
 		}
 
@@ -220,7 +221,7 @@ func purgeVolume(ctx context.Context, volID volumeID, cr *util.Credentials, volO
 	if err != nil {
 		klog.Errorf(util.Log(ctx, "failed to purge subvolume %s(%s) in fs %s"), string(volID), err, volOptions.FsName)
 
-		if strings.Contains(err.Error(), getVolumeNotFoundErrorString(volID)) {
+		if strings.HasPrefix(err.Error(), errNotFoundString) {
 			return ErrVolumeNotFound{err}
 		}
 


### PR DESCRIPTION
In some ceph version, if the subvolume is not present, the ceph returns doesnot exists and in some version not found
error message. This commit fixes issue for both error
checks.

By only checking Error ENOENT: for doesn't exist seems good. even if some error message changes in ceph ceph-csi won't get
any issue.

```bash
sh-4.2# ceph version
ceph version 14.2.10 (b340acf629a010a74d90da5782a2c5fe0b54ac20) nautilus (stable)

sh-4.2# ceph fs subvolume getpath myfs csi-vol-a24a3d97-c7f4-11ea-8cfc-0242ac110012 --group_name csi
Error ENOENT: subvolume 'csi-vol-a24a3d97-c7f4-11ea-8cfc-0242ac110012' does not exist
```

```bash
sh-4.2# ceph version
ceph version 14.2.4 (75f4de193b3ea58512f204623e6c5a16e6c1e1ba) nautilus (stable)

sh-4.2# ceph fs subvolume getpath myfs testing --group_name=csi
Error ENOENT: Subvolume 'testing' not found
```

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

backport of https://github.com/ceph/ceph-csi/pull/1247 to downstream 