### PR TITLE
Bug 1887556: rbd: Bail out from nodeexpansion if its block mode pvc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20200413115906-b5235f65be36 // indirect
-	google.golang.org/grpc v1.26.0
+	google.golang.org/grpc v1.27.0
 	gopkg.in/square/go-jose.v2 v2.5.0 // indirect
 	k8s.io/api v0.18.0
 	k8s.io/apimachinery v0.18.0

--- a/pkg/rbd/nodeserver.go
+++ b/pkg/rbd/nodeserver.go
@@ -641,21 +641,6 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandV
 	}
 	defer ns.VolumeLocks.Release(volumeID)
 
-	// volumePath is targetPath for block PVC and stagingPath for filesystem.
-	// check the path is mountpoint or not, if it is
-	// mountpoint treat this as block PVC or else it is filesystem PVC
-	// TODO remove this once ceph-csi supports CSI v1.2.0 spec
-	notMnt, err := mount.IsNotMountPoint(ns.mounter, volumePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if !notMnt {
-		return &csi.NodeExpandVolumeResponse{}, nil
-	}
-
 	devicePath, err := getDevicePath(ctx, volumePath)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())


### PR DESCRIPTION
At CSI spec < 1.2.0, there was no volumecapability in the
expand request. However its available from v1.2+ which allows
us to declare the node operations based on the volume mode.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Backported from https://github.com/ceph/ceph-csi/commit/1f5b84745facc983936ed2004f2bedc802fcec20, however cherry-pick was not possible because of the change in directory structure.
