### PR TITLE
KNIP-1542: RBD PV encryption using KMS type Hashicorp Vault

### DIFF
--- a/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-cephfs/templates/provisioner-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - "--timeout={{ .Values.provisioner.timeout }}"
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
+            - "--extra-create-metadata=true"
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}

--- a/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
+++ b/charts/ceph-csi-rbd/templates/nodeplugin-clusterrole.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.rbac.create -}}
-{{- if .Values.topology.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -11,8 +10,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+{{- if .Values.topology.enabled }}
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
 {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 {{- end -}}

--- a/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
+++ b/charts/ceph-csi-rbd/templates/provisioner-deployment.yaml
@@ -53,6 +53,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--default-fstype={{ .Values.provisioner.defaultFSType }}"
+            - "--extra-create-metadata=true"
 {{- if .Values.topology.enabled }}
             - "--feature-gates=Topology=true"
 {{- end }}

--- a/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
+++ b/deploy/cephfs/kubernetes/csi-cephfsplugin-provisioner.yaml
@@ -50,6 +50,7 @@ spec:
             - "--leader-election=true"
             - "--retry-interval-start=500ms"
             - "--feature-gates=Topology=false"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
+++ b/deploy/rbd/kubernetes/csi-nodeplugin-rbac.yaml
@@ -12,6 +12,9 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -53,6 +53,7 @@ spec:
             - "--feature-gates=Topology=false"
             # if fstype is not specified in storageclass, ext4 is default
             - "--default-fstype=ext4"
+            - "--extra-create-metadata=true"
           env:
             - name: ADDRESS
               value: unix:///csi/csi-provisioner.sock

--- a/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin-provisioner.yaml
@@ -133,6 +133,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # - name: POD_NAMESPACE
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: spec.namespace
+            # - name: KMS_CONFIGMAP_NAME
+            #   value: encryptionConfig
             - name: CSI_ENDPOINT
               value: unix:///csi/csi-provisioner.sock
           imagePullPolicy: "IfNotPresent"

--- a/deploy/rbd/kubernetes/csi-rbdplugin.yaml
+++ b/deploy/rbd/kubernetes/csi-rbdplugin.yaml
@@ -69,6 +69,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # - name: POD_NAMESPACE
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: spec.namespace
+            # - name: KMS_CONFIGMAP_NAME
+            #   value: encryptionConfig
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
           imagePullPolicy: "IfNotPresent"

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -236,7 +236,8 @@ There are two options to use Hashicorp Vault as a KMS:
 
 To use Vault as KMS set `encryptionKMSID` to a unique identifier for Vault
 configuration. You will also need to create vault configuration similar to the
-[example](../examples/rbd/kms-config.yaml) and use same `encryptionKMSID`.
+[example](../examples/kms/vault/kms-config.yaml) and use same
+`encryptionKMSID`.
 
 To use the Kubernetes ServiceAccount to access Vault, the configuration must
 include `encryptionKMSType: "vault"`. If Tenants are expected to place their
@@ -265,8 +266,9 @@ described in [official
 documentation](https://www.vaultproject.io/docs/auth/kubernetes.html).
 
 If token reviewer is used, you will need to configure service account for
-that also like in [example](../examples/rbd/csi-vaulttokenreview-rbac.yaml) to
-be able to review jwt tokens.
+that also like in
+[example](../examples/kms/vault/csi-vaulttokenreview-rbac.yaml) to be able to
+review jwt tokens.
 
 Configure a role(s) for service accounts used for ceph-csi:
 

--- a/docs/deploy-rbd.md
+++ b/docs/deploy-rbd.md
@@ -229,21 +229,36 @@ To further improve security robustness it is possible to use unique passphrases
 generated for each volume and stored in a Key Management System (KMS). Currently
 HashiCorp Vault is the only KMS supported.
 
+There are two options to use Hashicorp Vault as a KMS:
+
+1. with Kubernetes ServiceAccount
+1. with a Vault Token per Tenant (a Kubernetes Namespace)
+
 To use Vault as KMS set `encryptionKMSID` to a unique identifier for Vault
 configuration. You will also need to create vault configuration similar to the
 [example](../examples/rbd/kms-config.yaml) and use same `encryptionKMSID`.
-Configuration must include `encryptionKMSType: "vault"`. In order for ceph-csi
-to be able to access the configuration you will need to have it mounted to
-csi-rbdplugin containers in both daemonset (so kms client can be instantiated to
-encrypt/decrypt volumes) and deployment pods (so kms client can be instantiated
-to delete passphrase on volume delete) `ceph-csi-encryption-kms-config`
-configmap.
+
+To use the Kubernetes ServiceAccount to access Vault, the configuration must
+include `encryptionKMSType: "vault"`. If Tenants are expected to place their
+Vault Token in a Kubernetes Secret in their Namespace, set `encryptionKMSType:
+"vaulttokens"`.
+
+In order for ceph-csi to be able to access the configuration you will need to
+have it mounted to csi-rbdplugin containers in both daemonset (so kms client
+can be instantiated to encrypt/decrypt volumes) and deployment pods (so kms
+client can be instantiated to delete passphrase on volume delete)
+`ceph-csi-encryption-kms-config` configmap.
 
 > Note: kms configuration must be a map of string values only
 > (`map[string]string`) so for numerical and boolean values make sure to put
 > quotes around.
 
-#### Configuring HashiCorp Vault
+When the Tenants need to provide their own Vault Token, they will need to place
+it in a Kubernetes Secret (by default) called `ceph-csi-kms-token`, where the
+Vault Token is stored in the `token` key as shown in [the
+example](../examples/kms/vault/tenant-token.yaml).
+
+#### Configuring HashiCorp Vault with Kubernetes ServiceAccount
 
 Using Vault as KMS you need to configure Kubernetes authentication method as
 described in [official

--- a/docs/design/proposals/encryption-with-vault-tokens.md
+++ b/docs/design/proposals/encryption-with-vault-tokens.md
@@ -180,8 +180,73 @@ data:
   vaultBackendPath: "secret/ceph-csi-encryption/"
   vaultTLSServerName: "vault.infosec.example.org"
   vaultCAFromSecret: "vault-infosec-ca"
+  vaultClientCertFromSecret: "vault-client-cert"
+  vaultClientCertKeyFromSecret: "vault-client-cert-key"
   vaultCAVerify: "true"
 ```
 
 Only parameters with the `vault`-prefix may be changed in the Kubernetes
 ConfigMap of the Tenant.
+
+### Certificates stored in the Tenants Kubernetes Namespace
+
+The `vaultCAFromSecret` , `vaultClientCertFromSecret` and
+`vaultClientCertKeyFromSecret` secrets should be created in the namespace where
+Ceph-CSI is deployed. The sample of secrets for the CA and client Certificate.
+
+#### CA Certificate to verify Vault server TLS certificate
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-infosec-ca
+stringData:
+  ca.cert: |
+    MIIC2DCCAcCgAwIBAgIBATANBgkqh...
+```
+
+#### Client Certificate for Vault connection
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-client-cert
+stringData:
+  tls.cert: |
+    BATANBgkqcCgAwIBAgIBATANBAwI...
+```
+
+#### Client Certificate key for Vault connection
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-client-cert-key
+stringData:
+  tls.key: |
+    KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
+```
+
+Its also possible that a user can create a single secret for the certificates
+and update the configuration to fetch certificates from a secret.
+
+```yaml
+---
+apiVersion: v1
+kind: secret
+metadata:
+  name: vault-certificates
+stringData:
+  ca.cert: |
+    MIIC2DCCAcCgAwIBAgIBATANBgkqh...
+  tls.cert: |
+    BATANBgkqcCgAwIBAgIBATANBAwI...
+  tls.key: |
+    KNSC2DVVXcCgkqcCgAwIBAgIwewrvx...
+```

--- a/docs/design/proposals/encryption-with-vault-tokens.md
+++ b/docs/design/proposals/encryption-with-vault-tokens.md
@@ -1,0 +1,187 @@
+# Multi-tenancy with Vault Tokens
+
+## Current Feature: Vault access with single token
+
+The current feature to [support Hashicorp Vault as a KMS is
+documented](./encrypted-pvc.md):
+
+- Tenants can create PVCs that are encrypted with a unique key (Data Encryption
+  Key, DEK)
+- the key to encrypt/decrypt the PVC is stored in Hashicorp Vault
+- there is a single JSON Web Token (JWT), the Kubernetes ServiceAccount, to
+  access Vault
+- enabling is done in the StorageClass, pointing to a KMS configuration section
+  in a JSON configuration file (Kubernetes ConfigMap)
+
+## High-Level Requirements
+
+The new feature should support multi-tenancy, so that each Tenant can use their
+own Vault Token to access the Key Encryption Key (KEK) and fetch the Data
+Encryption Key (DEK) for PVC encryption:
+
+- each tenant can manage their Vault Token
+- to get the KEK from Vault, each Tenant should provide their personal Vault token
+- Ceph-CSI should use the Vault Token from the Tenant to store the unique key
+  (DEK) for the PVC
+- a Tenant is the owner of a Kubernetes Namespace
+
+## Restrictions to consider
+
+- Tenants can only configure their Kubernetes namespace, their token to access
+  Vault should be located in their namespace (as a Kubernetes Secret)
+- Ceph-CSI can not directly access Kubernetes namespaces, as CSI is an
+  abstraction layer
+- Ceph-CSI needs to talk to a service (sidecar) to access the Vault Token from
+  a Tenant
+- the KMS configuration is a ConfigMap with name
+  `ceph-csi-encryption-kms-config` in the namespace where the Ceph-CSI pods are
+  running
+- the KMS configuration is available for the Ceph-CSI pods at
+  `/etc/ceph-csi-encryption-kms-config/config.json`
+- [example of the
+  configuration](https://github.com/ceph/ceph-csi/blob/master/examples/kms/vault/kms-config.yaml)
+
+## Dependencies
+
+- the name of the Kubernetes Secret needs to be known (configured in the KMS
+  config file)
+- each Tenant (Kubernetes Namespace) should use the same name for the Secret
+  that contains the Vault token
+- the CSI-provisioner sidecar needs to provide the name of the Tenant together
+  with the metadata of the PVC to the Ceph-CSI provisioner
+
+## Implementation Outline
+
+- when creating the PVC the Ceph-CSI provisioner needs to store the Kubernetes
+  Namespace of the PVC in its metadata
+  - stores the `csi.volume.owner` (name of Tenant) in the metadata of the
+    volume and sets it as `rbdVolume.Owner`
+- the Ceph-CSI node-plugin needs to request the Vault Token in the NodeStage
+  CSI operation and create/get the key for the PVC
+- the Ceph-CSI provisioner needs to request the Vault Token to delete the key
+  for the PVC in the VolumeDelete CSI operation
+
+### New sidecar: Fetching Tenant Tokens from Kubernetes
+
+CSI is an abstraction and should not communicate with Kubernetes or other
+Container Orchestration systems directly. Therefore, it is needed to
+communicate with a service that can provide the Vault Token from the Tenants.
+This service can be provided by a sidecar, exposing an endpoint as a
+UNIX-Domain-Socket to communicate through.
+
+This sidecar does not exist at the moment. There are other features within
+Ceph-CSI that will benefit from this sidecar, e.g. Topology support. Because
+Ceph-CSI already uses the Kubernetes API to fetch details from Kubernetes, it
+should be acceptable to fetch the Vault Token configuration for the Tenants the
+same way.
+
+The feature for a sidecar that provides access to the required information from
+Kubernetes and other Container Orchestration frameworks is tracked in
+[#1782](https://github.com/ceph/ceph-csi/issues/1782).
+
+## Configuration Details
+
+- the current KMS configuration file needs extensions for Vault Token support
+- introduce a new KMS-type: VaultTokenKMS (the current VaultKMS uses a
+  Kubernetes ServiceAccount)
+- configuration of the VaultTokenKMS can be very similar to VaultKMS for common
+  settings
+- the configuration can override the defaults for each Tenant separately
+  - Vault Service connection details (address, TLS options, ...)
+  - name of the Kubernetes Secret that can be looked up per tenant
+- the configuration points to a Kubernetes Secret per Tenant that contains the
+  Vault Token
+- the configuration points to an optional Kubernetes ConfigMap per Tenant that
+  contains alternative connection options for the VaultTokenKMS service
+
+### Example of the KMS configuration file for Vault Tokens
+
+The configuration is available in the Ceph-CSI containers as
+`/etc/ceph-csi-encryption-kms-config/config.json`:
+
+```json
+{
+    "vault-with-tokens": {
+        "encryptionKMSType": "vaulttokens",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackendPath": "secret/",
+        "vaultTLSServerName": "vault.default.svc.cluster.local",
+        "vaultCAFromSecret": "vault-ca",
+        "vaultCAVerify": "false",
+        "tenantConfigName": "ceph-csi-kms-config",
+        "tenantTokenName": "ceph-csi-kms-token",
+        "tenants": {
+            "my-app": {
+                "vaultAddress": "https://vault.example.com",
+                "vaultCAVerify": "true"
+            },
+            "an-other-app": {
+                "tenantTokenName": "storage-encryption-token"
+            }
+        }
+    }
+}
+```
+
+In the Kubernetes StorageClass, the `kmsID` should be set to
+`vault-with-tokens` in order to select the above configuration.
+
+**Required options**:
+
+- `encryptionKMSType`: should be set to `vaulttokens`
+- `vaultAddress`: should be set to the URL of the Vault service
+
+**Optional options**:
+
+- `vaultBackendPath`: defaults to `secret/`
+- `vaultTLSServerName`: not used when unset
+- `vaultCAFromSecret`: not used when unset
+- `vaultCAVerify`: defaults to `true`
+- `tenantConfigName`: the name of the Kubernetes ConfigMap that contains the
+  Vault connection configuration (can be overridden per Tenant, defaults to
+  `ceph-csi-kms-config`)
+- `tenantTokenName`: the name of the Kubernetes Secret that contains the Vault
+  Token (can be overridden per Tenant, defaults to `ceph-csi-kms-token`)
+- `tenants`: list of Tenants (Kubernetes Namespaces) with their connection
+  configuration that differs from the global parameters
+
+### Configuration stored in the Tenants Kubernetes Namespace
+
+The Vault Token needs to be configured per Tenant. Each Tenant can create,
+modify or delete their own personal Token. The Token is stored in a Kubernetes
+Secret in the Kubernetes Namespace where the PVC is created.
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-csi-kms-token
+stringData:
+  token: "sample_root_token_id"
+```
+
+The name `ceph-csi-kms-token` is the default, but can be changed by setting
+`tenantTokenName` in the `/etc/ceph-csi-encryption-kms-config/config.json`
+configuration file.
+
+In addition to the Vault Token that can be configured per Tenant, the
+connection parameters to the Vault Service can be stored in the Tenants
+Kubernetes Namespace as well.
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-kms-config
+data:
+  vaultAddress: "https://vault.infosec.example.org"
+  vaultBackendPath: "secret/ceph-csi-encryption/"
+  vaultTLSServerName: "vault.infosec.example.org"
+  vaultCAFromSecret: "vault-infosec-ca"
+  vaultCAVerify: "true"
+```
+
+Only parameters with the `vault`-prefix may be changed in the Kubernetes
+ConfigMap of the Tenant.

--- a/e2e/rbd.go
+++ b/e2e/rbd.go
@@ -260,6 +260,15 @@ var _ = Describe("RBD", func() {
 				}
 			})
 
+			By("create a PVC and validate owner", func() {
+				err := validateImageOwner(pvcPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0)
+			})
+
 			By("create a PVC and bind it to an app", func() {
 				err := validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
@@ -1109,8 +1118,15 @@ var _ = Describe("RBD", func() {
 
 				updateConfigMap("e2e-ns")
 
+				err := validateImageOwner(pvcPath, f)
+				if err != nil {
+					e2elog.Failf("failed to validate owner of pvc with error %v", err)
+				}
+				// validate created backend rbd images
+				validateRBDImageCount(f, 0)
+
 				// Create a PVC and bind it to an app within the namesapce
-				err := validatePVCAndAppBinding(pvcPath, appPath, f)
+				err = validatePVCAndAppBinding(pvcPath, appPath, f)
 				if err != nil {
 					e2elog.Failf("failed to validate pvc and application binding with error %v", err)
 				}

--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -12,7 +12,25 @@ data:
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
-      }
+      },
+      "vault-tokens-test": {
+          "encryptionKMSType": "vaulttokens",
+          "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackendPath": "secret/",
+          "vaultTLSServerName": "vault.default.svc.cluster.local",
+          "vaultCAVerify": "false",
+          "tenantConfigName": "ceph-csi-kms-config",
+          "tenantTokenName": "ceph-csi-kms-token",
+          "tenants": {
+              "my-app": {
+                  "vaultAddress": "https://vault.example.com",
+                  "vaultCAVerify": "true"
+              },
+              "an-other-app": {
+                  "tenantTokenName": "storage-encryption-token"
+              }
+          }
+       }
     }
 metadata:
   name: ceph-csi-encryption-kms-config

--- a/examples/kms/vault/tenant-config.yaml
+++ b/examples/kms/vault/tenant-config.yaml
@@ -1,0 +1,12 @@
+---
+# This is an optional (re)configuration of the connection to the Vault
+# Service that can be created in a Kubernetes Namespace for a Tenant.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ceph-csi-kms-config
+data:
+  vaultAddress: "http://vault.default.svc.cluster.local:8200"
+  vaultBackendPath: "secret/"
+  vaultTLSServerName: "vault.default.svc.cluster.local"
+  vaultCAVerify: "false"

--- a/examples/kms/vault/tenant-token.yaml
+++ b/examples/kms/vault/tenant-token.yaml
@@ -1,0 +1,9 @@
+---
+# This is the Vault Token that can be created in a Kubernetes Namespace
+# (Tenant) for encrypting PVCs with the "vaulttokens" encryptionKMSType.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ceph-csi-kms-token
+stringData:
+  token: "sample_root_token_id"

--- a/internal/cephfs/fsjournal.go
+++ b/internal/cephfs/fsjournal.go
@@ -232,7 +232,7 @@ func reserveVol(ctx context.Context, volOptions *volumeOptions, secret map[strin
 	imageUUID, vid.FsSubvolName, err = j.ReserveName(
 		ctx, volOptions.MetadataPool, util.InvalidPoolID,
 		volOptions.MetadataPool, util.InvalidPoolID, volOptions.RequestName,
-		volOptions.NamePrefix, "", "", volOptions.ReservedID)
+		volOptions.NamePrefix, "", "", volOptions.ReservedID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func reserveSnap(ctx context.Context, volOptions *volumeOptions, parentSubVolNam
 	imageUUID, vid.FsSnapshotName, err = j.ReserveName(
 		ctx, volOptions.MetadataPool, util.InvalidPoolID,
 		volOptions.MetadataPool, util.InvalidPoolID, snap.RequestName,
-		snap.NamePrefix, parentSubVolName, "", snap.ReservedID)
+		snap.NamePrefix, parentSubVolName, "", snap.ReservedID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rbd/rbd_journal.go
+++ b/internal/rbd/rbd_journal.go
@@ -344,7 +344,7 @@ func reserveSnap(ctx context.Context, rbdSnap *rbdSnapshot, rbdVol *rbdVolume, c
 
 	rbdSnap.ReservedID, rbdSnap.RbdSnapName, err = j.ReserveName(
 		ctx, rbdSnap.JournalPool, journalPoolID, rbdSnap.Pool, imagePoolID,
-		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, "", rbdSnap.ReservedID)
+		rbdSnap.RequestName, rbdSnap.NamePrefix, rbdVol.RbdImageName, "", rbdSnap.ReservedID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}
@@ -422,7 +422,7 @@ func reserveVol(ctx context.Context, rbdVol *rbdVolume, rbdSnap *rbdSnapshot, cr
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID)
+		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, rbdVol.ReservedID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}
@@ -542,6 +542,7 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 	if imageData != nil {
 		rbdVol.ReservedID = imageData.ImageUUID
 		rbdVol.ImageID = imageData.ImageAttributes.ImageID
+		rbdVol.Owner = imageData.ImageAttributes.Owner
 		if rbdVol.ImageID == "" {
 			err = rbdVol.storeImageID(ctx, j)
 			if err != nil {
@@ -559,7 +560,7 @@ func RegenerateJournal(imageName, volumeID, pool, journalPool, requestName strin
 
 	rbdVol.ReservedID, rbdVol.RbdImageName, err = j.ReserveName(
 		ctx, rbdVol.JournalPool, journalPoolID, rbdVol.Pool, imagePoolID,
-		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID)
+		rbdVol.RequestName, rbdVol.NamePrefix, "", kmsID, vi.ObjectUUID, rbdVol.Owner)
 	if err != nil {
 		return err
 	}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -169,6 +169,9 @@ func (rv *rbdVolume) Destroy() {
 	if rv.conn != nil {
 		rv.conn.Destroy()
 	}
+	if rv.KMS != nil {
+		rv.KMS.Destroy()
+	}
 }
 
 // String returns the image-spec (pool/{namespace/}image) format of the image.

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -740,7 +740,7 @@ func genVolFromVolID(ctx context.Context, volumeID string, cr *util.Credentials,
 
 	if imageAttributes.KmsID != "" {
 		rbdVol.Encrypted = true
-		rbdVol.KMS, err = util.GetKMS(imageAttributes.KmsID, secrets)
+		rbdVol.KMS, err = util.GetKMS(rbdVol.Owner, imageAttributes.KmsID, secrets)
 		if err != nil {
 			return rbdVol, err
 		}
@@ -838,7 +838,7 @@ func genVolFromVolumeOptions(ctx context.Context, volOptions, credentials map[st
 			// deliberately ignore if parsing failed as GetKMS will return default
 			// implementation of kmsID is empty
 			kmsID := volOptions["encryptionKMSID"]
-			rbdVol.KMS, err = util.GetKMS(kmsID, credentials)
+			rbdVol.KMS, err = util.GetKMS(rbdVol.Owner, kmsID, credentials)
 			if err != nil {
 				return nil, fmt.Errorf("invalid encryption kms configuration: %s", err)
 			}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -51,6 +51,7 @@ const (
 // EncryptionKMS provides external Key Management System for encryption
 // passphrases storage.
 type EncryptionKMS interface {
+	Destroy()
 	GetPassphrase(key string) (string, error)
 	SavePassphrase(key, value string) error
 	DeletePassphrase(key string) error
@@ -73,6 +74,11 @@ func initSecretsKMS(secrets map[string]string) (EncryptionKMS, error) {
 		return nil, errors.New("missing encryption passphrase in secrets")
 	}
 	return SecretsKMS{passphrase: passphraseValue}, nil
+}
+
+// Destroy frees all used resources.
+func (kms SecretsKMS) Destroy() {
+	// nothing to do
 }
 
 // GetPassphrase returns passphrase from Kubernetes secrets.

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -141,7 +141,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	case kmsTypeVault:
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
 	case kmsTypeVaultTokens:
-		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)
+		return InitVaultTokensKMS(tenant, kmsID, kmsConfig)
 	}
 	return nil, fmt.Errorf("unknown encryption KMS type %s", kmsType)
 }

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -97,7 +97,13 @@ func (kms SecretsKMS) GetID() string {
 }
 
 // GetKMS returns an instance of Key Management System.
-func GetKMS(kmsID string, secrets map[string]string) (EncryptionKMS, error) {
+//
+// - tenant is the owner of the Volume, used to fetch the Vault Token from the
+//   Kubernetes Namespace where the PVC lives
+// - kmsID is the service name of the KMS configuration
+// - secrets contain additional details, like TLS certificates to connect to
+//   the KMS
+func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, error) {
 	if kmsID == "" || kmsID == defaultKMSType {
 		return initSecretsKMS(secrets)
 	}

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -138,7 +138,7 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 	}
 
 	switch kmsType {
-	case "vault":
+	case kmsTypeVault:
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
 	case kmsTypeVaultTokens:
 		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -137,8 +137,11 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 		return nil, fmt.Errorf("encryption KMS configuration for %s is missing KMS type", kmsID)
 	}
 
-	if kmsType == "vault" {
+	switch kmsType {
+	case "vault":
 		return InitVaultKMS(kmsID, kmsConfig, secrets)
+	case kmsTypeVaultTokens:
+		return InitVaultTokensKMS(tenant, kmsID, kmsConfig, secrets)
 	}
 	return nil, fmt.Errorf("unknown encryption KMS type %s", kmsType)
 }

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -115,17 +115,9 @@ func GetKMS(kmsID string, secrets map[string]string) (EncryptionKMS, error) {
 		return nil, fmt.Errorf("failed to parse kms configuration: %s", err)
 	}
 
-	kmsConfigData, ok := config[kmsID].(map[string]interface{})
+	kmsConfig, ok := config[kmsID].(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("missing encryption KMS configuration with %s", kmsID)
-	}
-	kmsConfig := make(map[string]string)
-	for key, value := range kmsConfigData {
-		kmsConfig[key], ok = value.(string)
-		if !ok {
-			return nil, fmt.Errorf("broken KMS config: '%s' for '%s' is not a string",
-				value, key)
-		}
 	}
 
 	kmsType, ok := kmsConfig[kmsTypeKey]

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -107,7 +107,7 @@ func setConfigString(option *string, config map[string]interface{}, key string) 
 	return nil
 }
 
-func (vc *vaultConnection) initConnection(kmsID string, config, secrets map[string]string) error {
+func (vc *vaultConnection) initConnection(kmsID string, config map[string]interface{}, secrets map[string]string) error {
 	vaultConfig := make(map[string]interface{})
 	keyContext := make(map[string]string)
 
@@ -165,7 +165,7 @@ func (vc *vaultConnection) initConnection(kmsID string, config, secrets map[stri
 }
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.
-func InitVaultKMS(kmsID string, config, secrets map[string]string) (EncryptionKMS, error) {
+func InitVaultKMS(kmsID string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
 	kms := &VaultKMS{}
 	err := kms.initConnection(kmsID, config, secrets)
 	if err != nil {

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	kmsTypeVault = "vault"
+
 	// path to service account token that will be used to authenticate with Vault
 	// #nosec
 	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -167,7 +167,6 @@ func (vc *vaultConnection) initConnection(kmsID string, config map[string]interf
 		if err != nil {
 			return fmt.Errorf("failed to create temporary file for Vault CA: %w", err)
 		}
-		// TODO: delete f.Name() when vaultConnection is destroyed
 	}
 
 	// update the existing config only if no config is available yet
@@ -199,6 +198,18 @@ func (vc *vaultConnection) connectVault() error {
 	vc.secrets = v
 
 	return nil
+}
+
+// Destroy frees allocated resources. For a vaultConnection that means removing
+// the created temporary files.
+func (vc *vaultConnection) Destroy() {
+	if vc.vaultConfig != nil {
+		tmpFile, ok := vc.vaultConfig[api.EnvVaultCACert]
+		if ok {
+			// ignore error on failure to remove tmpfile (gosec complains)
+			_ = os.Remove(tmpFile.(string))
+		}
+	}
 }
 
 // InitVaultKMS returns an interface to HashiCorp Vault KMS.

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/vault/api"
+	loss "github.com/libopenstorage/secrets"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kmsTypeVaultTokens = "vaulttokens"
+
+	// vaultTokensDefaultConfigName is the name of the Kubernetes ConfigMap
+	// that contains the Vault connection configuration for the tenant.
+	// This ConfigMap is located in the Kubernetes Namespace where the
+	// tenant created the PVC.
+	//
+	// #nosec:G101, value not credential, just references token.
+	vaultTokensDefaultConfigName = "ceph-csi-kms-config"
+
+	// vaultTokensDefaultTokenName is the name of the Kubernetes Secret
+	// that contains the Vault Token for the tenant.  This Secret is
+	// located in the Kubernetes Namespace where the tenant created the
+	// PVC.
+	//
+	// #nosec:G101, value not credential, just references token.
+	vaultTokensDefaultTokenName = "ceph-csi-kms-token"
+
+	// vaultTokenSecretKey refers to the key in the Kubernetes Secret that
+	// contains the VAULT_TOKEN.
+	vaultTokenSecretKey = "token"
+)
+
+/*
+VaultTokens represents a Hashicorp Vault KMS configuration that provides a
+Token per tenant.
+
+Example JSON structure in the KMS config is,
+{
+    "vault-with-tokens": {
+        "encryptionKMSType": "vaulttokens",
+        "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackendPath": "secret/",
+        "vaultTLSServerName": "vault.default.svc.cluster.local",
+        "vaultCAFromSecret": "vault-ca",
+        "vaultCAVerify": "false",
+        "tenantConfigName": "ceph-csi-kms-config",
+        "tenantTokenName": "ceph-csi-kms-token",
+        "tenants": {
+            "my-app": {
+                "vaultAddress": "https://vault.example.com",
+                "vaultCAVerify": "true"
+            },
+            "an-other-app": {
+                "tenantTokenName": "storage-encryption-token"
+            }
+	},
+	...
+}.
+*/
+type VaultTokensKMS struct {
+	vaultConnection
+
+	// Tenant is the name of the owner of the volume
+	Tenant string
+	// ConfigName is the name of the ConfigMap in the Tenants Kubernetes Namespace
+	ConfigName string
+	// TokenName is the name of the Secret in the Tenants Kubernetes Namespace
+	TokenName string
+}
+
+// InitVaultTokensKMS returns an interface to HashiCorp Vault KMS.
+func InitVaultTokensKMS(tenant, kmsID string, config map[string]interface{}, secrets map[string]string) (EncryptionKMS, error) {
+	kms := &VaultTokensKMS{}
+	err := kms.initConnection(kmsID, config, secrets)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize Vault connection: %w", err)
+	}
+
+	// set default values for optional config options
+	kms.ConfigName = vaultTokensDefaultConfigName
+	kms.TokenName = vaultTokensDefaultTokenName
+
+	err = kms.parseConfig(config, secrets)
+	if err != nil {
+		return nil, err
+	}
+
+	// fetch the configuration for the tenant
+	if tenant != "" {
+		tenantsMap, ok := config["tenants"]
+		if ok {
+			// tenants is a map per tenant, containing key/values
+			tenants, ok := tenantsMap.(map[string]map[string]interface{})
+			if ok {
+				// get the map for the tenant of the current operation
+				tenantConfig, ok := tenants[tenant]
+				if ok {
+					// override connection details from the tenant
+					err = kms.parseConfig(tenantConfig, secrets)
+					if err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+	}
+
+	// fetch the Vault Token from the Secret (TokenName) in the Kubernetes
+	// Namespace (tenant)
+	kms.vaultConfig[api.EnvVaultToken], err = getToken(tenant, kms.TokenName)
+	if err != nil {
+		return nil, fmt.Errorf("failed fetching token from %s/%s: %w", tenant, kms.TokenName, err)
+	}
+
+	// connect to the Vault service
+	err = kms.connectVault()
+	if err != nil {
+		return nil, err
+	}
+
+	return kms, nil
+}
+
+// parseConfig updates the kms.vaultConfig with the options from config and
+// secrets. This method can be called multiple times, i.e. to override
+// configuration options from tenants.
+func (kms *VaultTokensKMS) parseConfig(config map[string]interface{}, secrets map[string]string) error {
+	err := kms.initConnection(kms.EncryptionKMSID, config, secrets)
+	if err != nil {
+		return err
+	}
+
+	err = setConfigString(&kms.ConfigName, config, "tenantConfigName")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+
+	err = setConfigString(&kms.TokenName, config, "tenantTokenName")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+
+	return nil
+}
+
+// GetPassphrase returns passphrase from Vault. The passphrase is stored in a
+// data.data.passphrase structure.
+func (kms *VaultTokensKMS) GetPassphrase(key string) (string, error) {
+	s, err := kms.secrets.GetSecret(key, kms.keyContext)
+	if errors.Is(err, loss.ErrInvalidSecretId) {
+		return "", MissingPassphrase{err}
+	} else if err != nil {
+		return "", err
+	}
+
+	data, ok := s["data"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("failed parsing data for get passphrase request for %s", key)
+	}
+	passphrase, ok := data["passphrase"].(string)
+	if !ok {
+		return "", fmt.Errorf("failed parsing passphrase for get passphrase request for %s", key)
+	}
+
+	return passphrase, nil
+}
+
+// SavePassphrase saves new passphrase in Vault.
+func (kms *VaultTokensKMS) SavePassphrase(key, value string) error {
+	data := map[string]interface{}{
+		"data": map[string]string{
+			"passphrase": value,
+		},
+	}
+
+	err := kms.secrets.PutSecret(key, data, kms.keyContext)
+	if err != nil {
+		return fmt.Errorf("saving passphrase at %s request to vault failed: %w", key, err)
+	}
+
+	return nil
+}
+
+// DeletePassphrase deletes passphrase from Vault.
+func (kms *VaultTokensKMS) DeletePassphrase(key string) error {
+	err := kms.secrets.DeleteSecret(key, kms.keyContext)
+	if err != nil {
+		return fmt.Errorf("delete passphrase at %s request to vault failed: %w", key, err)
+	}
+
+	return nil
+}
+
+func getToken(tenant, tokenName string) (string, error) {
+	c := NewK8sClient()
+	secret, err := c.CoreV1().Secrets(tenant).Get(context.TODO(), tokenName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	token, ok := secret.Data[vaultTokenSecretKey]
+	if !ok {
+		return "", errors.New("failed to parse token")
+	}
+
+	return string(token), nil
+}

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -26,10 +26,9 @@ func TestParseConfig(t *testing.T) {
 	kms := VaultTokensKMS{}
 
 	config := make(map[string]interface{})
-	secrets := make(map[string]string)
 
 	// empty config map
-	err := kms.parseConfig(config, secrets)
+	err := kms.parseConfig(config)
 	if !errors.Is(err, errConfigOptionMissing) {
 		t.Errorf("unexpected error (%T): %s", err, err)
 	}
@@ -40,7 +39,7 @@ func TestParseConfig(t *testing.T) {
 	config["tenantTokenName"] = vaultTokensDefaultTokenName
 
 	// parsing with all required options
-	err = kms.parseConfig(config, secrets)
+	err = kms.parseConfig(config)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
@@ -53,7 +52,7 @@ func TestParseConfig(t *testing.T) {
 	// tenant "bob" uses a different kms.ConfigName
 	bob := make(map[string]interface{})
 	bob["tenantConfigName"] = "the-config-from-bob"
-	err = kms.parseConfig(bob, secrets)
+	err = kms.parseConfig(bob)
 	switch {
 	case err != nil:
 		t.Errorf("unexpected error: %s", err)
@@ -75,10 +74,9 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	}
 
 	config := make(map[string]interface{})
-	secrets := make(map[string]string)
 
 	// empty config map
-	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if !errors.Is(err, errConfigOptionMissing) {
 		t.Errorf("unexpected error (%T): %s", err, err)
 	}
@@ -87,7 +85,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["vaultAddress"] = "https://vault.default.cluster.svc"
 
 	// parsing with all required options
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -97,7 +95,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["tenants"] = tenants
 
 	// empty tenants list
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}
@@ -107,7 +105,7 @@ func TestInitVaultTokensKMS(t *testing.T) {
 	config["tenants"].(map[string]interface{})["bob"] = bob
 	bob["vaultAddress"] = "https://vault.bob.example.org"
 
-	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config)
 	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
 		t.Errorf("unexpected error: %s", err)
 	}

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Ceph-CSI Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	kms := VaultTokensKMS{}
+
+	config := make(map[string]interface{})
+	secrets := make(map[string]string)
+
+	// empty config map
+	err := kms.parseConfig(config, secrets)
+	if !errors.Is(err, errConfigOptionMissing) {
+		t.Errorf("unexpected error (%T): %s", err, err)
+	}
+
+	// fill default options (normally done in InitVaultTokensKMS)
+	config["vaultAddress"] = "https://vault.default.cluster.svc"
+	config["tenantConfigName"] = vaultTokensDefaultConfigName
+	config["tenantTokenName"] = vaultTokensDefaultTokenName
+
+	// parsing with all required options
+	err = kms.parseConfig(config, secrets)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case kms.ConfigName != vaultTokensDefaultConfigName:
+		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
+	case kms.TokenName != vaultTokensDefaultTokenName:
+		t.Errorf("TokenName contains unexpected value: %s", kms.TokenName)
+	}
+
+	// tenant "bob" uses a different kms.ConfigName
+	bob := make(map[string]interface{})
+	bob["tenantConfigName"] = "the-config-from-bob"
+	err = kms.parseConfig(bob, secrets)
+	switch {
+	case err != nil:
+		t.Errorf("unexpected error: %s", err)
+	case kms.ConfigName != "the-config-from-bob":
+		t.Errorf("ConfigName contains unexpected value: %s", kms.ConfigName)
+	}
+}
+
+// TestInitVaultTokensKMS verifies that passing partial and complex
+// configurations get applied correctly.
+//
+// When vault.New() is called at the end of InitVaultTokensKMS(), errors will
+// mention the missing VAULT_TOKEN, and that is expected.
+func TestInitVaultTokensKMS(t *testing.T) {
+	if true {
+		// FIXME: testing only works when KUBE_CONFIG is set to a
+		// cluster that has a working Vault deployment
+		return
+	}
+
+	config := make(map[string]interface{})
+	secrets := make(map[string]string)
+
+	// empty config map
+	_, err := InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if !errors.Is(err, errConfigOptionMissing) {
+		t.Errorf("unexpected error (%T): %s", err, err)
+	}
+
+	// fill required options
+	config["vaultAddress"] = "https://vault.default.cluster.svc"
+
+	// parsing with all required options
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// fill tenants
+	tenants := make(map[string]interface{})
+	config["tenants"] = tenants
+
+	// empty tenants list
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// add tenant "bob"
+	bob := make(map[string]interface{})
+	config["tenants"].(map[string]interface{})["bob"] = bob
+	bob["vaultAddress"] = "https://vault.bob.example.org"
+
+	_, err = InitVaultTokensKMS("bob", "vault-tokens-config", config, secrets)
+	if err != nil && !strings.Contains(err.Error(), "VAULT_TOKEN") {
+		t.Errorf("unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
This is a backport of the following PRs from the upstream ceph-csi project:

- [x]  deploy: Enable `extraCreateMetadata` for provisioner #1093
- [x]  doc: multi-tenancy with Vault tokens #1743 
- [x]  doc: add usage for Vault Tokens KMS support #1783 
- [x]  doc: add usage for Vault Tokens KMS support #1783 
- [x]  Add support for a KMS configuration that uses Vault Tokens #1759 
- [x]  util: add support for vault certificates #1787 
- [x]  VaultToken Tenants should be able to (re)configure the connection to the Vault Service #1788 
- [x]  rbd: read configuration from the configmap #1789 