### PR TITLE
RHSTOR-1378: add support for Multus

### DIFF
--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -289,7 +289,7 @@ func detachRBDDevice(ctx context.Context, devicePath, volumeID, unmapOptions str
 
 // detachRBDImageOrDeviceSpec detaches an rbd imageSpec or devicePath, with additional checking
 // when imageSpec is used to decide if image is already unmapped.
-func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, isImageSpec, ndbType, encrypted bool, volumeID, unmapOptions string) error {
+func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, isImageSpec, isNbd, encrypted bool, volumeID, unmapOptions string) error {
 	if encrypted {
 		mapperFile, mapperPath := util.VolumeMapper(volumeID)
 		mappedDevice, mapper, err := util.DeviceEncryptionStatus(ctx, mapperPath)
@@ -311,7 +311,7 @@ func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, i
 	}
 
 	accessType := accessTypeKRbd
-	if ndbType {
+	if isNbd {
 		accessType = accessTypeNbd
 	}
 	unmapArgs := []string{"unmap", "--device-type", accessType, imageOrDeviceSpec}

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -215,7 +215,15 @@ func appendDeviceTypeAndOptions(cmdArgs []string, isNbd bool, userOptions string
 	}
 
 	cmdArgs = append(cmdArgs, "--device-type", accessType)
+	if !isNbd {
+		// Enable mapping and unmapping images from a non-initial network
+		// namespace (e.g. for Multus CNI).  The network namespace must be
+		// owned by the initial user namespace.
+		cmdArgs = append(cmdArgs, "--options", "noudev")
+	}
 	if userOptions != "" {
+		// userOptions is appended after, possibly overriding the above
+		// default options.
 		cmdArgs = append(cmdArgs, "--options", userOptions)
 	}
 

--- a/internal/rbd/rbd_attach.go
+++ b/internal/rbd/rbd_attach.go
@@ -214,8 +214,7 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 
 	util.TraceLog(ctx, "rbd: map mon %s", volOpt.Monitors)
 
-	// Map options
-	mapOptions := []string{
+	mapArgs := []string{
 		"--id", cr.ID,
 		"-m", volOpt.Monitors,
 		"--keyfile=" + cr.KeyFile,
@@ -230,17 +229,17 @@ func createPath(ctx context.Context, volOpt *rbdVolume, cr *util.Credentials) (s
 	}
 
 	// Update options with device type selection
-	mapOptions = append(mapOptions, "--device-type", accessType)
+	mapArgs = append(mapArgs, "--device-type", accessType)
 
 	if volOpt.readOnly {
-		mapOptions = append(mapOptions, "--read-only")
+		mapArgs = append(mapArgs, "--read-only")
 	}
 
 	if volOpt.MapOptions != "" {
-		mapOptions = append(mapOptions, "--options", volOpt.MapOptions)
+		mapArgs = append(mapArgs, "--options", volOpt.MapOptions)
 	}
 	// Execute map
-	stdout, stderr, err := util.ExecCommand(ctx, rbd, mapOptions...)
+	stdout, stderr, err := util.ExecCommand(ctx, rbd, mapArgs...)
 	if err != nil {
 		util.WarningLog(ctx, "rbd: map error %v, rbd output: %s", err, stderr)
 		// unmap rbd image if connection timeout
@@ -315,11 +314,12 @@ func detachRBDImageOrDeviceSpec(ctx context.Context, imageOrDeviceSpec string, i
 	if ndbType {
 		accessType = accessTypeNbd
 	}
-	options := []string{"unmap", "--device-type", accessType, imageOrDeviceSpec}
+	unmapArgs := []string{"unmap", "--device-type", accessType, imageOrDeviceSpec}
 	if unmapOptions != "" {
-		options = append(options, "--options", unmapOptions)
+		unmapArgs = append(unmapArgs, "--options", unmapOptions)
 	}
-	_, stderr, err := util.ExecCommand(ctx, rbd, options...)
+
+	_, stderr, err := util.ExecCommand(ctx, rbd, unmapArgs...)
 	if err != nil {
 		// Messages for krbd and nbd differ, hence checking either of them for missing mapping
 		// This is not applicable when a device path is passed in


### PR DESCRIPTION
This is a backport of ceph/ceph-csi#1450 from @idryomov. As such, it also depends on ceph/ceph#36927 being backported to downstream.

Ilya, is the `--options noudev` option already available in downstream Ceph container images? Only when that is the case, this PR should get merged, I guess. In case Ceph ignores unknown options, then merging this change will not hurt.

[RHSTOR-1378](https://issues.redhat.com/browse/RHSTOR-1378) is part of [KNIP-1470](https://issues.redhat.com/browse/KNIP-1470).