### PR TITLE
BUG 1921521: util: convert VAULT_SKIP_VERIFY to "vaultCAVerify" KMS option

### DIFF
--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -63,7 +63,7 @@ type standardVault struct {
 	VaultClientCert    string `json:"VAULT_CLIENT_CERT"`
 	VaultClientKey     string `json:"VAULT_CLIENT_KEY"`
 	VaultNamespace     string `json:"VAULT_NAMESPACE"`
-	VaultSkipVerify    *bool  `json:"VAULT_SKIP_VERIFY"`
+	VaultSkipVerify    string `json:"VAULT_SKIP_VERIFY"`
 }
 
 type vaultTokenConf struct {
@@ -91,8 +91,9 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	// by default the CA should get verified, only when VaultSkipVerify is
 	// set, verification should be disabled
 	v.VaultCAVerify = "true"
-	if s.VaultSkipVerify != nil {
-		v.VaultCAVerify = strconv.FormatBool(*s.VaultSkipVerify)
+	verify, err := strconv.ParseBool(s.VaultSkipVerify)
+	if err == nil {
+		v.VaultCAVerify = strconv.FormatBool(!verify)
 	}
 }
 


### PR DESCRIPTION
"VAULT_SKIP_VERIFY" is a standard Hashicorp Vault environment variable
(a string) that needs to get converted to the "vaultCAVerify"
configuration option in the Ceph-CSI format.

The value of "VAULT_SKIP_VERIFY" means the reverse of "vaultCAVerify",
this part was missing in the original conversion too.

Backport-off: ceph/ceph-csi#1872
Signed-off-by: Niels de Vos <ndevos@redhat.com>
(cherry picked from commit 2c38f8425495ea6f9688fcf550adb7c5ff9e0b22)
