### PR TITLE
ocs: add initial ocs/README.md

### DIFF
--- a/ocs/Containerfile
+++ b/ocs/Containerfile
@@ -1,0 +1,35 @@
+# This Containerfile is used by openshift-ci to build the image, and push it to
+# quay.io/ocs-dev/ceph-csi
+#
+# This image is based on the latest stable Ceph version, which uses CentOS.
+#
+# Note that other tests run on the latest Fedora release. That makes the binary
+# that gets build not necessary compatible with the Ceph version on other
+# distributions. Hence the need to rebuild the executable on the OS that will
+# be used as deployment image.
+
+FROM docker.io/ceph/daemon-base:latest AS builder
+
+ENV GOPATH=/go
+
+# install dependencies
+RUN dnf -y install \
+        golang \
+        make \
+        librados-devel \
+        librbd-devel \
+    && dnf -y update \
+    && dnf clean all \
+    && true
+
+# compile and link the executable
+RUN cd /go/src/github.com/ceph/ceph-csi && make
+
+# final container to use in deployments
+FROM docker.io/ceph/daemon-base:latest
+
+COPY --from=builder /go/src/github.com/ceph/ceph-csi/_output/cephcsi /usr/local/bin/cephcsi
+
+RUN chmod +x /usr/local/bin/cephcsi
+
+ENTRYPOINT ["/usr/local/bin/cephcsi"]

--- a/ocs/README.md
+++ b/ocs/README.md
@@ -1,0 +1,42 @@
+# Ceph-CSI Stream
+
+Ceph-CSI Stream is the Red Hat downstream project that contains the pre-release
+state of Ceph-CSI as used in the OpenShift Container Storage product.
+
+## Git Repository
+
+### Branches
+
+This GitHub repository contains branches for different product versions.
+
+### Pull Requests
+
+Once
+the product planning entered feature freeze, only backports with related
+Bugzilla references will be allowed to get merged.
+
+### Downstream-Only Changes
+
+For working with the downstream tools, like OpenShift CI, there are a few
+changes required that are not suitable for the upstream Ceph-CSI project.
+
+1. `OWNERS` file: added with maintainers for reviewing and approving PRs
+1. `ocs/` directory: additional files (like this `README.md`)
+1. `ocs/Containerfile`: used to build the quay.io/ocs-dev/ceph-csi image
+
+## Continious Integration
+
+OpenShift CI (Prow) is used for testing the changes that land in this GitHub
+repository. The configuration of the jobs can be found in the [OpenShift
+Release repository][ocp-release].
+
+### Bugzilla Plugin
+
+PRs that need a Bugzilla reference are handled by the Bugzilla Plugin which
+runs as part of Prow. The configuration gates the requirement on BZs to be
+linked, before the tests will pass and the PR can be merged. Once a branch is
+added to the GitHub repository, [the configuration][bz-config] needs adaption
+for the new branch as well.
+
+[ocp-release]: https://github.com/openshift/release/tree/master/ci-operator/config/openshift/ceph-csi
+[bz-config]: https://github.com/openshift/release/blob/master/core-services/prow/02_config/_plugins.yaml


### PR DESCRIPTION
The new README.md describes how this repository is used, and what
processes there are in place.

This is an initial version, and should get extended with more details
whenever something needs further clarifications.

The ocs/Containerfile will be used to build the Ceph-CSI Stream
container images for quay.io/ocs-dev/ceph-csi.
