### PR TITLE
doc: explain more details about backporting from upstream (downstream only)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/00_ocs-backport.md
+++ b/.github/PULL_REQUEST_TEMPLATE/00_ocs-backport.md
@@ -1,0 +1,20 @@
+---
+name: Backport changes from upstream for a release
+about: Use this template when backporting changes from the master branch to a release.
+title: "Bug 000000: description of the change"
+---
+
+**You must EDIT ME! The contents below is an example only.**
+
+Bug 000000 gets hit when the system is out for its birthday party. After
+providing the system with sufficient cake, it returns to normal business the
+next day.
+
+I hereby confirm that:
+
+- [ ] this change is in the upstream project (*reference?*)
+- [ ] this change is in the master branch of this project
+- [ ] branches for higher versions of the project have this change merged
+- [ ] this PR is not *downstream-only*, if that was the case, I would have
+  explained its need very clearly
+

--- a/.github/PULL_REQUEST_TEMPLATE/00_ocs-downstream-only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/00_ocs-downstream-only.md
@@ -1,0 +1,14 @@
+---
+name: Downstream-only change, unrelated to upstream project
+about: |-
+  Use this template when a change in the repository is needed, that does not
+  need to be included in the upstream project.
+title: "COMPONENT: description of the change"
+labels: downstream-only
+---
+
+**You must EDIT ME! The contents below is an example only.**
+
+The downstream CI testing depends on additional settings in the Search
+Optimization so that the project contributors can get a piece of chocolate for
+every merged PR.

--- a/.github/PULL_REQUEST_TEMPLATE/00_ocs-sync.md
+++ b/.github/PULL_REQUEST_TEMPLATE/00_ocs-sync.md
@@ -1,0 +1,16 @@
+---
+name: Sync branch from upstream
+about: Use this template for syncing upstream changes into downstream.
+title: "Sync current state f from [UPSTREAM:BRANCH] to [BRANCH]"
+labels: rebase
+---
+
+**You must EDIT ME! The contents below is an example only.**
+
+Sync the upstream changes from `ceph/ceph-csi:devel` into the `master` branch.
+The most importand recent changes that we want included are:
+
+- the new foz bar baz works flawlessly
+- this addresses a bug where users are facing issues with XYZ
+- ...
+

--- a/ocs/README.md
+++ b/ocs/README.md
@@ -23,6 +23,7 @@ changes required that are not suitable for the upstream Ceph-CSI project.
 1. `OWNERS` file: added with maintainers for reviewing and approving PRs
 1. `ocs/` directory: additional files (like this `README.md`)
 1. `ocs/Containerfile`: used to build the quay.io/ocs-dev/ceph-csi image
+1. `.github/PULL_REQUEST_TEMPLATE/00_ocs-*`: guidance for creating PRs
 
 ## Continious Integration
 

--- a/ocs/README.md
+++ b/ocs/README.md
@@ -9,10 +9,37 @@ state of Ceph-CSI as used in the OpenShift Container Storage product.
 
 This GitHub repository contains branches for different product versions.
 
+## Backports
+
+All changes in this repository are *backports* from the [upstream
+project][upstream-ceph-csi]. There should be no functional changes (only
+process/CI/building/..) in this repository compared to the upstream project.
+Fixes for any of the release branches should first land in the master branch
+before they may be backported to the release branch. A backport for the oldest
+release should also be backported to all the newer releases in order to prevent
+re-introducing a bug when a user updates.
+
+### Sync `master` with upstream `ceph/ceph-csi:devel`
+
+Syncing branches (including the `master` branch) from upstream should be done
+with a Pull-Request. To create a PR that syncs the latest changes from
+`ceph/ceph-csi:devel` into the `master branch`, [click here][sync-pr].
+
+### Backporting changes from the `master` to `release-*` branches
+
+Once a PR has been merged in the master branch that fixes an issue. A new PR
+with the backport can be created. The easiest way is to use a command like
+
+```
+/cherry-pick release-4.8
+```
+
+The **openshift-cherrypick-robot** will automatically create a new PR for the
+selected branch.
+
 ### Pull Requests
 
-Once
-the product planning entered feature freeze, only backports with related
+Once the product planning enters feature freeze, only backports with related
 Bugzilla references will be allowed to get merged.
 
 ### Downstream-Only Changes
@@ -39,5 +66,7 @@ linked, before the tests will pass and the PR can be merged. Once a branch is
 added to the GitHub repository, [the configuration][bz-config] needs adaption
 for the new branch as well.
 
+[upstream-ceph-csi]: https://github.com/ceph/ceph-csi
+[sync-pr]: https://github.com/openshift/ceph-csi/compare/master...ceph:devel
 [ocp-release]: https://github.com/openshift/release/tree/master/ci-operator/config/openshift/ceph-csi
 [bz-config]: https://github.com/openshift/release/blob/master/core-services/prow/02_config/_plugins.yaml


### PR DESCRIPTION
The `ocs/README.md` should contain as much details as possible. It now
includes a description of how to sync the `master` branch with the
upstream project, and cherry-pick changes to release branches.

These templates will guide contributors to the project with providing
details about the changes.

Examples include:
- syncing from upstream
- backports for bug fixes
- downstream only changes (like this PR)

/cc @agarwal-mudit 
/assign @humblec 