### PR TITLE
rbd: update build tag in snapshot_octopus.go vendor (downstream only)

### DIFF
--- a/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
+++ b/vendor/github.com/ceph/go-ceph/rbd/snapshot_octopus.go
@@ -1,4 +1,6 @@
 // +build octopus
+// These snapshot APIs are not available in the RHCS build used by OCS.
+// +build rhcs_next
 
 package rbd
 


### PR DESCRIPTION
the downstream ceph version does not have `C.rbd_snap_get_id` and `C.rbd_snap_get_name` in librbd API's. as cephcsi is not using any function from this file. removing this file to fix the build issue.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>

