### PR TITLE
BUG 1832297: Provide capacity of block-mode RBD volumes

### DIFF
--- a/e2e/pvc.go
+++ b/e2e/pvc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -243,4 +244,45 @@ func checkPVSelectorValuesForPVC(f *framework.Framework, pvc *v1.PersistentVolum
 		}
 	}
 	return nil
+}
+
+func getMetricsForPVC(f *framework.Framework, pvc *v1.PersistentVolumeClaim, t int) error {
+	kubelet, err := getKubeletIP(f.ClientSet)
+	if err != nil {
+		return err
+	}
+
+	// kubelet needs to be started with --read-only-port=10255
+	cmd := fmt.Sprintf("curl --silent 'http://%s:10255/metrics'", kubelet)
+
+	// retry as kubelet does not immediately have the metrics available
+	timeout := time.Duration(t) * time.Minute
+	return wait.PollImmediate(poll, timeout, func() (bool, error) {
+		stdOut, stdErr, err := execCommandInToolBoxPod(f, cmd, rookNamespace)
+		if err != nil {
+			e2elog.Logf("failed to get metrics for pvc %q (%v): %v", pvc.Name, err, stdErr)
+			return false, nil
+		}
+		if stdOut == "" {
+			e2elog.Logf("no metrics received from kublet on IP %s", kubelet)
+			return false, nil
+		}
+
+		namespace := fmt.Sprintf("namespace=%q", pvc.Namespace)
+		name := fmt.Sprintf("persistentvolumeclaim=%q", pvc.Name)
+
+		for _, line := range strings.Split(stdOut, "\n") {
+			if !strings.HasPrefix(line, "kubelet_volume_stats_") {
+				continue
+			}
+			if strings.Contains(line, namespace) && strings.Contains(line, name) {
+				// TODO: validate metrics if possible
+				e2elog.Logf("found metrics for pvc %s/%s: %s", pvc.Namespace, pvc.Name, line)
+				return true, nil
+			}
+		}
+
+		e2elog.Logf("no metrics found for pvc %s/%s", pvc.Namespace, pvc.Name)
+		return false, nil
+	})
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -302,6 +302,19 @@ func validateNormalUserPVCAccess(pvcPath string, f *framework.Framework) error {
 	if stdErr != "" {
 		return fmt.Errorf("failed to touch a file as non-root user %v", stdErr)
 	}
+
+	// metrics for BlockMode was added in Kubernetes 1.22
+	isBlockMode := false
+	if pvc.Spec.VolumeMode != nil {
+		isBlockMode = (*pvc.Spec.VolumeMode == v1.PersistentVolumeBlock)
+	}
+	if !isBlockMode || k8sVersionGreaterEquals(f.ClientSet, 1, 22) {
+		err = getMetricsForPVC(f, pvc, deployTimeout)
+		if err != nil {
+			return err
+		}
+	}
+
 	err = deletePod(app.Name, app.Namespace, f.ClientSet, deployTimeout)
 	if err != nil {
 		return err

--- a/internal/csi-common/nodeserver-default.go
+++ b/internal/csi-common/nodeserver-default.go
@@ -17,18 +17,13 @@ limitations under the License.
 package csicommon
 
 import (
-	"fmt"
-	"os"
+	"context"
 
 	"github.com/ceph/ceph-csi/internal/util"
-
-	"context"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/volume"
 )
 
 // DefaultNodeServer stores driver object.
@@ -85,94 +80,7 @@ func (ns *DefaultNodeServer) NodeGetCapabilities(ctx context.Context, req *csi.N
 
 // NodeGetVolumeStats returns volume stats.
 func (ns *DefaultNodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	var err error
-	targetPath := req.GetVolumePath()
-	if targetPath == "" {
-		err = fmt.Errorf("targetpath %v is empty", targetPath)
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	/*
-		volID := req.GetVolumeId()
-
-		TODO: Map the volumeID to the targetpath.
-
-		CephFS:
-		   we need secret to connect to the ceph cluster to get the volumeID from volume
-		   Name, however `secret` field/option is not available  in NodeGetVolumeStats spec,
-		   Below issue covers this request and once its available, we can do the validation
-		   as per the spec.
-
-		   https://github.com/container-storage-interface/spec/issues/371
-
-		RBD:
-		   Below issue covers this request for RBD and once its available, we can do the validation
-		   as per the spec.
-
-		   https://github.com/ceph/ceph-csi/issues/511
-
-	*/
-
-	isMnt, err := util.IsMountPoint(targetPath)
-
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, status.Errorf(codes.InvalidArgument, "targetpath %s does not exist", targetPath)
-		}
-		return nil, err
-	}
-	if !isMnt {
-		return nil, status.Errorf(codes.InvalidArgument, "targetpath %s is not mounted", targetPath)
-	}
-
-	cephMetricsProvider := volume.NewMetricsStatFS(targetPath)
-	volMetrics, volMetErr := cephMetricsProvider.GetMetrics()
-	if volMetErr != nil {
-		return nil, status.Error(codes.Internal, volMetErr.Error())
-	}
-
-	available, ok := (*(volMetrics.Available)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch available bytes"))
-	}
-	capacity, ok := (*(volMetrics.Capacity)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch capacity bytes"))
-		return nil, status.Error(codes.Unknown, "failed to fetch capacity bytes")
-	}
-	used, ok := (*(volMetrics.Used)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch used bytes"))
-	}
-	inodes, ok := (*(volMetrics.Inodes)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch available inodes"))
-		return nil, status.Error(codes.Unknown, "failed to fetch available inodes")
-	}
-	inodesFree, ok := (*(volMetrics.InodesFree)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch free inodes"))
-	}
-
-	inodesUsed, ok := (*(volMetrics.InodesUsed)).AsInt64()
-	if !ok {
-		klog.Errorf(util.Log(ctx, "failed to fetch used inodes"))
-	}
-	return &csi.NodeGetVolumeStatsResponse{
-		Usage: []*csi.VolumeUsage{
-			{
-				Available: available,
-				Total:     capacity,
-				Used:      used,
-				Unit:      csi.VolumeUsage_BYTES,
-			},
-			{
-				Available: inodesFree,
-				Total:     inodes,
-				Used:      inodesUsed,
-				Unit:      csi.VolumeUsage_INODES,
-			},
-		},
-	}, nil
+	return nil, status.Error(codes.Unimplemented, "")
 }
 
 // ConstructMountOptions returns only unique mount options in slice.


### PR DESCRIPTION
The capacity breakdown card under Persistent storage Tab, does not list the namespaces which only have RBD (block) PVCs. All the other namespaces containing cephfs and RBD (file) PVCs are listed. 

On expanding the card using the 'View more' option, the namespaces corresponding to the RBD(block) PVCs are not listed there either.

This change depends on openshift/kubernetes#731 ([RHBZ#1927359](https://bugzilla.redhat.com/1927359)) before its effect will be visible.

I hereby confirm that:

- [x] this change is in the upstream project (ceph/ceph-csi#1831)
- [x] this change is in the master branch of this project (#48)
- [x] branches for higher versions of the project have this change merged
- [x] this PR is not *downstream-only*, if that was the case, I would have
  explained its need very clearly

