### PR TITLE
Bug 1969427: util: returns actual error instead of ErrPoolNotFound

### DIFF
--- a/internal/util/cephcmds.go
+++ b/internal/util/cephcmds.go
@@ -92,9 +92,11 @@ func GetPoolName(monitors string, cr *Credentials, poolID int64) (string, error)
 	defer connPool.Put(conn)
 
 	name, err := conn.GetPoolByID(poolID)
-	if err != nil {
-		return "", fmt.Errorf("%w: pool ID (%d) not found in Ceph cluster",
+	if errors.Is(err, rados.ErrNotFound) {
+		return "", fmt.Errorf("%w: pool ID(%d) not found in Ceph cluster",
 			ErrPoolNotFound, poolID)
+	} else if err != nil {
+		return "", fmt.Errorf("failed to get pool ID %d: %w", poolID, err)
 	}
 	return name, nil
 }


### PR DESCRIPTION
This commit returns actual error returned by the go-ceph API
to the function GetPoolName(..) instead of just returning
ErrPoolNotFound everytime there is error getting the pool id.
There is a issue reported in which the snapshot creation
takes much more time to reach True state
(i.e., between 2-7 mins) and keeps trying to create with
below error though pool is present:
rpc error: code = NotFound desc = pool not found: pool ID (21)
not found in Ceph cluster.

Since we cannot interpret the actual error for the delay in
snapshot creation, it is required to return the actual error
as well so that we can uderstand the reason.

Signed-off-by: Yati Padia <ypadia@redhat.com>
(cherry picked from commit 5ae82c261837f8a47a54fe81cbaaf60468aa6eba)
