### PR TITLE
BUG 1973046: rbd: fail fast in create volume for mismatch encryption

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1528,3 +1528,15 @@ func (rv *rbdVolume) getOrigSnapName(snapID uint64) (string, error) {
 
 	return origSnapName, nil
 }
+
+func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
+	switch {
+	case ri.isEncrypted() && !dst.isEncrypted():
+		return fmt.Errorf("encrypted volume %q does not match unencrypted volume %q", ri, dst)
+
+	case !ri.isEncrypted() && dst.isEncrypted():
+		return fmt.Errorf("unencrypted volume %q does not match encrypted volume %q", ri, dst)
+	}
+
+	return nil
+}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1532,10 +1532,10 @@ func (rv *rbdVolume) getOrigSnapName(snapID uint64) (string, error) {
 func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
 	switch {
 	case ri.isEncrypted() && !dst.isEncrypted():
-		return fmt.Errorf("encrypted volume %q does not match unencrypted volume %q", ri, dst)
+		return fmt.Errorf("cannot create unencrypted volume from encrypted volume %q", ri)
 
 	case !ri.isEncrypted() && dst.isEncrypted():
-		return fmt.Errorf("unencrypted volume %q does not match encrypted volume %q", ri, dst)
+		return fmt.Errorf("cannot create encrypted volume from unencrypted volume %q", ri)
 	}
 
 	return nil


### PR DESCRIPTION
commit 1:

rbd: fail fast in create volume for mismatch encryption
    
    CreateVolume will fail in the below cases
    
    * If the snapshot is encrypted and requested volume
    is not encrypted
    * If the snapshot is not encrypted and requested
    volume is encrypted
    
    * If the parent volume is encrypted and requested volume
    is not encrypted
    * If the parent volume is not encrypted and requested
    volume is encrypted
    
    Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
    (cherry picked from commit 186cae5956d6aa9b1590a9b2fcd513626e98da59)

* commit 2:

rbd: correct return error for isCompatibleEncryption
    
    isCompatibleEncryption is used to validate the
    requested volume and the existing volume and
    the destination volume name wont be generated yet
    and logging the destination volume prints the empty
    image name with pool name.
    
    Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>
    (cherry picked from commit 367eb9f7485f9d2a305343587844678027aa2d78)
