### PR TITLE
BUG 1973271: rbd: add validation for thick restore/clone

### DIFF
--- a/internal/rbd/controllerserver.go
+++ b/internal/rbd/controllerserver.go
@@ -222,8 +222,18 @@ func checkValidCreateVolumeRequest(rbdVol, parentVol *rbdVolume, rbdSnap *rbdSna
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
 		}
+
+		err = rbdSnap.isCompatibleThickProvision(rbdVol)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot restore from snapshot %s: %s", rbdSnap, err.Error())
+		}
 	case parentVol != nil:
 		err = parentVol.isCompatibleEncryption(&rbdVol.rbdImage)
+		if err != nil {
+			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
+		}
+
+		err = parentVol.isCompatibleThickProvision(rbdVol)
 		if err != nil {
 			return status.Errorf(codes.InvalidArgument, "cannot clone from volume %s: %s", parentVol, err.Error())
 		}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1425,13 +1425,13 @@ func (rv *rbdVolume) setThickProvisioned() error {
 // isThickProvisioned checks in the image metadata if the image has been marked
 // as thick-provisioned. This can be used while expanding the image, so that
 // the expansion can be allocated too.
-func (rv *rbdVolume) isThickProvisioned() (bool, error) {
-	value, err := rv.GetMetadata(thickProvisionMetaKey)
+func (ri *rbdImage) isThickProvisioned() (bool, error) {
+	value, err := ri.GetMetadata(thickProvisionMetaKey)
 	if err != nil {
 		if err == librbd.ErrNotFound {
 			return false, nil
 		}
-		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, rv.String(), err)
+		return false, fmt.Errorf("failed to get metadata %q for %q: %w", thickProvisionMetaKey, ri, err)
 	}
 
 	thick, err := strconv.ParseBool(value)

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1540,3 +1540,19 @@ func (ri *rbdImage) isCompatibleEncryption(dst *rbdImage) error {
 
 	return nil
 }
+
+func (ri *rbdImage) isCompatibleThickProvision(dst *rbdVolume) error {
+	thick, err := ri.isThickProvisioned()
+	if err != nil {
+		return err
+	}
+	switch {
+	case thick && !dst.ThickProvision:
+		return fmt.Errorf("cannot create thin volume from thick volume %q", ri)
+
+	case !thick && dst.ThickProvision:
+		return fmt.Errorf("cannot create thick volume from thin volume %q", ri)
+	}
+
+	return nil
+}

--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -1556,3 +1556,31 @@ func (ri *rbdImage) isCompatibleThickProvision(dst *rbdVolume) error {
 
 	return nil
 }
+
+// FIXME: merge isCompatibleThickProvision of rbdSnapshot and rbdImage to a single
+// function.
+func (rs *rbdSnapshot) isCompatibleThickProvision(dst *rbdVolume) error {
+	// During CreateSnapshot the rbd image will be created with the
+	// snapshot name. Replacing RbdImageName with RbdSnapName so that we
+	// can check if the image is thick provisioned
+	vol := generateVolFromSnap(rs)
+	err := vol.Connect(rs.conn.Creds)
+	if err != nil {
+		return err
+	}
+	defer vol.Destroy()
+
+	thick, err := vol.isThickProvisioned()
+	if err != nil {
+		return err
+	}
+	switch {
+	case thick && !dst.ThickProvision:
+		return fmt.Errorf("cannot create thin volume from thick volume %q", vol)
+
+	case !thick && dst.ThickProvision:
+		return fmt.Errorf("cannot create thick volume from thin volume %q", vol)
+	}
+
+	return nil
+}


### PR DESCRIPTION
added validation to allow only Restore of Thick PVC snapshot to a thick clone and creation of a thick clone from thick PVC.

Signed-off-by: Madhu Rajanna madhupr007@gmail.com

backport of https://github.com/ceph/ceph-csi/pull/2174