### PR TITLE
BUG 1979604: util: convert standardVault object to map

### DIFF
--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -152,9 +152,14 @@ func GetKMS(tenant, kmsID string, secrets map[string]string) (EncryptionKMS, err
 		}
 	}
 
-	kmsConfig, ok := config[kmsID].(map[string]interface{})
+	kmsMap, ok := config[kmsID]
 	if !ok {
-		return nil, fmt.Errorf("missing encryption KMS configuration with %s", kmsID)
+		return nil, fmt.Errorf("missing encryption KMS configuration with %q", kmsID)
+	}
+
+	kmsConfig, ok := kmsMap.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to convert encryption KMS configuration %q", kmsID)
 	}
 
 	kmsType, ok := kmsConfig[kmsTypeKey]

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -100,7 +100,7 @@ func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 // dataToStandardVault takes the contents from a single connection
 // configuration from the ConfigMap and converts the UI options to values that
 // the VaultTokens KMS implementation understands.
-func dataToStandardVault(k, v string) (*standardVault, error) {
+func dataToStandardVault(k, v string) (map[string]interface{}, error) {
 	sv := &standardVault{}
 	err := json.Unmarshal([]byte(v), sv)
 	if err != nil {
@@ -118,7 +118,7 @@ func dataToStandardVault(k, v string) (*standardVault, error) {
 		return nil, fmt.Errorf("failed to Unmarshal the CSI vault configuration for %q: %w", k, err)
 	}
 
-	return sv, nil
+	return jsonMap, nil
 }
 
 // dataToMap converts a json blob containing Vault configuration options to a map.


### PR DESCRIPTION
getVaultConfiguration() parses the standardVault object from the
ConfigMap. It then sets the value to the given KMS-ID. Unfortunately
the value is in the form of a standardVault object, where a
map[string]interface{} is expected.

It seems that dataToStandardVault() converts the standardVault object to
the correct format, but does not return it. By addressing this problem,
the configuration from the ConfigMap gets parsed and converted correctly
again.

**This change is downstream only, upstream parses the KMS configuration differently.**
