### PR TITLE
BUG 1983931: util: allow configuring VAULT_BACKEND for Vault connection

### DIFF
--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -9,6 +9,7 @@ data:
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
         "vaultAuthPath": "/v1/auth/kubernetes/login",
         "vaultRole": "csi-kubernetes",
+        "vaultBackend": "kv-v2",
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
@@ -16,6 +17,7 @@ data:
       "vault-tokens-test": {
           "encryptionKMSType": "vaulttokens",
           "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackend": "kv-v2",
           "vaultBackendPath": "secret/",
           "vaultTLSServerName": "vault.default.svc.cluster.local",
           "vaultCAVerify": "false",

--- a/examples/kms/vault/tenant-config.yaml
+++ b/examples/kms/vault/tenant-config.yaml
@@ -7,6 +7,7 @@ metadata:
   name: ceph-csi-kms-config
 data:
   vaultAddress: "http://vault.default.svc.cluster.local:8200"
+  vaultBackend: "kv-v2"
   vaultBackendPath: "secret/"
   vaultTLSServerName: "vault.default.svc.cluster.local"
   vaultCAVerify: "false"

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -133,6 +133,16 @@ func (vc *vaultConnection) initConnection(kmsID string, config map[string]interf
 	}
 	// default: !firstInit
 
+	vaultBackend := "" // optional
+	err = setConfigString(&vaultBackend, config, "vaultBackend")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+	// set the option if the value was not invalid
+	if !errors.Is(err, errConfigOptionMissing) {
+		vaultConfig[vault.VaultBackendKey] = vaultBackend
+	}
+
 	vaultBackendPath := "" // optional
 	err = setConfigString(&vaultBackendPath, config, "vaultBackendPath")
 	if errors.Is(err, errConfigOptionInvalid) {

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -57,6 +57,7 @@ const (
 type standardVault struct {
 	KmsPROVIDER        string `json:"KMS_PROVIDER"`
 	VaultADDR          string `json:"VAULT_ADDR"`
+	VaultBackend       string `json:"VAULT_BACKEND"`
 	VaultBackendPath   string `json:"VAULT_BACKEND_PATH"`
 	VaultCACert        string `json:"VAULT_CACERT"`
 	VaultTLSServerName string `json:"VAULT_TLS_SERVER_NAME"`
@@ -69,6 +70,7 @@ type standardVault struct {
 type vaultTokenConf struct {
 	EncryptionKMSType            string `json:"encryptionKMSType"`
 	VaultAddress                 string `json:"vaultAddress"`
+	VaultBackend                 string `json:"vaultBackend"`
 	VaultBackendPath             string `json:"vaultBackendPath"`
 	VaultCAFromSecret            string `json:"vaultCAFromSecret"`
 	VaultTLSServerName           string `json:"vaultTLSServerName"`
@@ -81,6 +83,7 @@ type vaultTokenConf struct {
 func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	v.EncryptionKMSType = s.KmsPROVIDER
 	v.VaultAddress = s.VaultADDR
+	v.VaultBackend = s.VaultBackend
 	v.VaultBackendPath = s.VaultBackendPath
 	v.VaultCAFromSecret = s.VaultCACert
 	v.VaultClientCertFromSecret = s.VaultClientCert
@@ -214,6 +217,7 @@ Example JSON structure in the KMS config is,
     "vault-with-tokens": {
         "encryptionKMSType": "vaulttokens",
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackend": "kv-v2",
         "vaultBackendPath": "secret/",
         "vaultTLSServerName": "vault.default.svc.cluster.local",
         "vaultCAFromSecret": "vault-ca",
@@ -504,6 +508,7 @@ func getCertificate(tenant, secretName, key string) (string, error) {
 func isTenantConfigOption(opt string) bool {
 	switch opt {
 	case "vaultAddress":
+	case "vaultBackend":
 	case "vaultBackendPath":
 	case "vaultTLSServerName":
 	case "vaultCAFromSecret":

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -120,6 +120,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 	vaultConfigMap := `{
 		"KMS_PROVIDER":"vaulttokens",
 		"VAULT_ADDR":"https://vault.example.com",
+		"VAULT_BACKEND":"kv-v2",
 		"VAULT_BACKEND_PATH":"/secret",
 		"VAULT_CACERT":"",
 		"VAULT_TLS_SERVER_NAME":"vault.example.com",
@@ -144,6 +145,8 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 		t.Errorf("unexpected value for EncryptionKMSType: %s", v.EncryptionKMSType)
 	case v.VaultAddress != "https://vault.example.com":
 		t.Errorf("unexpected value for VaultAddress: %s", v.VaultAddress)
+	case v.VaultBackend != "kv-v2":
+		t.Errorf("unexpected value for VaultBackend: %s", v.VaultBackend)
 	case v.VaultBackendPath != "/secret":
 		t.Errorf("unexpected value for VaultBackendPath: %s", v.VaultBackendPath)
 	case v.VaultCAFromSecret != "":
@@ -193,6 +196,7 @@ func TestDataToMap(t *testing.T) {
 		"vaultAddress": "http://vault.default.svc.cluster.local:8200",
 		"vaultAuthPath": "/v1/auth/kubernetes/login",
 		"vaultRole": "csi-kubernetes",
+		"vaultBackend": "kv-v2",
 		"vaultPassphraseRoot": "/v1/secret",
 		"vaultPassphrasePath": "ceph-csi/",
 		"vaultCAVerify": "false"
@@ -203,6 +207,7 @@ func TestDataToMap(t *testing.T) {
 		"vaultAddress":        "http://vault.default.svc.cluster.local:8200",
 		"vaultAuthPath":       "/v1/auth/kubernetes/login",
 		"vaultRole":           "csi-kubernetes",
+		"vaultBackend":        "kv-v2",
 		"vaultPassphraseRoot": "/v1/secret",
 		"vaultPassphrasePath": "ceph-csi/",
 		"vaultCAVerify":       "false",
@@ -231,6 +236,7 @@ func TestCMToConfig(t *testing.T) {
 		"KMS_PROVIDER":"vaulttokens",
 		"KMS_SERVICE_NAME":"vault",
 		"VAULT_ADDR":"https://vault.qe.rh-ocs.com:8200",
+		"VAULT_BACKEND":"kv-v2",
 		"VAULT_BACKEND_PATH":"rbd-encryption",
 		"VAULT_CACERT":"ocs-kms-ca-secret-cp6wg",
 		"VAULT_TLS_SERVER_NAME":"",
@@ -247,6 +253,7 @@ func TestCMToConfig(t *testing.T) {
 		"vaultAddress": "http://vault.default.svc.cluster.local:8200",
 		"vaultAuthPath": "/v1/auth/kubernetes/login",
 		"vaultRole": "csi-kubernetes",
+		"vaultBackend": "kv-v2",
 		"vaultPassphraseRoot": "/v1/secret",
 		"vaultPassphrasePath": "ceph-csi/",
 		"vaultCAVerify": "false"


### PR DESCRIPTION
It seems that the version of the key/value engine can not always be
detected for Hashicorp Vault. In certain cases, it is required to
configure the `VAULT_BACKEND` (or `vaultBackend`) option so that a
successful connection to the service can be made.

The `kv-v2` is the current default for development deployments of
Hashicorp Vault (what we use for automated testing). Production
deployments default to version 1 for now.

Backport-of: ceph/ceph-csi#2307