### PR TITLE
Bug 1984333: util: allow configuring VAULT_BACKEND for Vault connection

### DIFF
--- a/examples/kms/vault/kms-config.yaml
+++ b/examples/kms/vault/kms-config.yaml
@@ -9,6 +9,7 @@ data:
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
         "vaultAuthPath": "/v1/auth/kubernetes/login",
         "vaultRole": "csi-kubernetes",
+        "vaultBackend": "kv-v2",
         "vaultPassphraseRoot": "/v1/secret",
         "vaultPassphrasePath": "ceph-csi/",
         "vaultCAVerify": "false"
@@ -16,6 +17,7 @@ data:
       "vault-tokens-test": {
           "encryptionKMSType": "vaulttokens",
           "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+          "vaultBackend": "kv-v2",
           "vaultBackendPath": "secret/",
           "vaultTLSServerName": "vault.default.svc.cluster.local",
           "vaultCAVerify": "false",

--- a/examples/kms/vault/tenant-config.yaml
+++ b/examples/kms/vault/tenant-config.yaml
@@ -7,6 +7,7 @@ metadata:
   name: ceph-csi-kms-config
 data:
   vaultAddress: "http://vault.default.svc.cluster.local:8200"
+  vaultBackend: "kv-v1"
   vaultBackendPath: "secret/"
   vaultTLSServerName: "vault.default.svc.cluster.local"
   vaultCAVerify: "false"

--- a/internal/util/vault.go
+++ b/internal/util/vault.go
@@ -131,6 +131,16 @@ func (vc *vaultConnection) initConnection(config map[string]interface{}) error {
 	}
 	// default: !firstInit
 
+	vaultBackend := "" // optional
+	err = setConfigString(&vaultBackend, config, "vaultBackend")
+	if errors.Is(err, errConfigOptionInvalid) {
+		return err
+	}
+	// set the option if the value was not invalid
+	if !errors.Is(err, errConfigOptionMissing) {
+		vaultConfig[vault.VaultBackendKey] = vaultBackend
+	}
+
 	vaultBackendPath := "" // optional
 	err = setConfigString(&vaultBackendPath, config, "vaultBackendPath")
 	if errors.Is(err, errConfigOptionInvalid) {

--- a/internal/util/vault_tokens.go
+++ b/internal/util/vault_tokens.go
@@ -56,6 +56,7 @@ const (
 type standardVault struct {
 	KmsPROVIDER        string `json:"KMS_PROVIDER"`
 	VaultADDR          string `json:"VAULT_ADDR"`
+	VaultBackend       string `json:"VAULT_BACKEND"`
 	VaultBackendPath   string `json:"VAULT_BACKEND_PATH"`
 	VaultCACert        string `json:"VAULT_CACERT"`
 	VaultTLSServerName string `json:"VAULT_TLS_SERVER_NAME"`
@@ -68,6 +69,7 @@ type standardVault struct {
 type vaultTokenConf struct {
 	EncryptionKMSType            string `json:"encryptionKMSType"`
 	VaultAddress                 string `json:"vaultAddress"`
+	VaultBackend                 string `json:"vaultBackend"`
 	VaultBackendPath             string `json:"vaultBackendPath"`
 	VaultCAFromSecret            string `json:"vaultCAFromSecret"`
 	VaultTLSServerName           string `json:"vaultTLSServerName"`
@@ -80,6 +82,7 @@ type vaultTokenConf struct {
 func (v *vaultTokenConf) convertStdVaultToCSIConfig(s *standardVault) {
 	v.EncryptionKMSType = s.KmsPROVIDER
 	v.VaultAddress = s.VaultADDR
+	v.VaultBackend = s.VaultBackend
 	v.VaultBackendPath = s.VaultBackendPath
 	v.VaultCAFromSecret = s.VaultCACert
 	v.VaultClientCertFromSecret = s.VaultClientCert
@@ -145,6 +148,7 @@ Example JSON structure in the KMS config is,
     "vault-with-tokens": {
         "encryptionKMSType": "vaulttokens",
         "vaultAddress": "http://vault.default.svc.cluster.local:8200",
+        "vaultBackend": "kv-v2",
         "vaultBackendPath": "secret/",
         "vaultTLSServerName": "vault.default.svc.cluster.local",
         "vaultCAFromSecret": "vault-ca",
@@ -445,6 +449,7 @@ func getCertificate(tenant, secretName, key string) (string, error) {
 func isTenantConfigOption(opt string) bool {
 	switch opt {
 	case "vaultAddress":
+	case "vaultBackend":
 	case "vaultBackendPath":
 	case "vaultTLSServerName":
 	case "vaultCAFromSecret":

--- a/internal/util/vault_tokens_test.go
+++ b/internal/util/vault_tokens_test.go
@@ -125,6 +125,7 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 	vaultConfigMap := `{
 		"KMS_PROVIDER":"vaulttokens",
 		"VAULT_ADDR":"https://vault.example.com",
+		"VAULT_BACKEND":"kv-v2",
 		"VAULT_BACKEND_PATH":"/secret",
 		"VAULT_CACERT":"",
 		"VAULT_TLS_SERVER_NAME":"vault.example.com",
@@ -149,6 +150,8 @@ func TestStdVaultToCSIConfig(t *testing.T) {
 		t.Errorf("unexpected value for EncryptionKMSType: %s", v.EncryptionKMSType)
 	case v.VaultAddress != "https://vault.example.com":
 		t.Errorf("unexpected value for VaultAddress: %s", v.VaultAddress)
+	case v.VaultBackend != "kv-v2":
+		t.Errorf("unexpected value for VaultBackend: %s", v.VaultBackend)
 	case v.VaultBackendPath != "/secret":
 		t.Errorf("unexpected value for VaultBackendPath: %s", v.VaultBackendPath)
 	case v.VaultCAFromSecret != "":
@@ -170,6 +173,7 @@ func TestTransformConfig(t *testing.T) {
 	cm := make(map[string]interface{})
 	cm["KMS_PROVIDER"] = "vaulttokens"
 	cm["VAULT_ADDR"] = "https://vault.example.com"
+	cm["VAULT_BACKEND"] = "kv-v2"
 	cm["VAULT_BACKEND_PATH"] = "/secret"
 	cm["VAULT_CACERT"] = ""
 	cm["VAULT_TLS_SERVER_NAME"] = "vault.example.com"
@@ -182,6 +186,7 @@ func TestTransformConfig(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, config["encryptionKMSType"], cm["KMS_PROVIDER"])
 	assert.Equal(t, config["vaultAddress"], cm["VAULT_ADDR"])
+	assert.Equal(t, config["vaultBackend"], cm["VAULT_BACKEND"])
 	assert.Equal(t, config["vaultBackendPath"], cm["VAULT_BACKEND_PATH"])
 	assert.Equal(t, config["vaultCAFromSecret"], cm["VAULT_CACERT"])
 	assert.Equal(t, config["vaultTLSServerName"], cm["VAULT_TLS_SERVER_NAME"])


### PR DESCRIPTION
It seems that the version of the key/value engine can not always be
detected for Hashicorp Vault. In certain cases, it is required to
configure the `VAULT_BACKEND` (or `vaultBackend`) option so that a
successful connection to the service can be made.

The `kv-v2` is the current default for development deployments of
Hashicorp Vault (what we use for automated testing). Production
deployments default to version 1 for now.

Signed-off-by: Niels de Vos <ndevos@redhat.com>
(cherry picked from commit a5211dcf0e17b1790e0dd7621855210a74787dd2)
