### PR TITLE
Bug 1995047: rbd: fix typo in error message

### DIFF
--- a/internal/rbd/rbd_util.go
+++ b/internal/rbd/rbd_util.go
@@ -254,7 +254,7 @@ func createImage(ctx context.Context, pOpts *rbdVolume, cr *util.Credentials) er
 	if pOpts.isEncrypted() {
 		err = pOpts.setupEncryption(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to setup encroption for image %s: %v", pOpts, err)
+			return fmt.Errorf("failed to setup encryption for image %s: %v", pOpts, err)
 		}
 	}
 


### PR DESCRIPTION
fixed typo in error message.
This commit refers to the below PR:
https://github.com/ceph/ceph-csi/pull/2112

Signed-off-by: yati1998 <ypadia@redhat.com>
